### PR TITLE
Refactoring ios storyboards

### DIFF
--- a/xikolo-ios.xcodeproj/project.pbxproj
+++ b/xikolo-ios.xcodeproj/project.pbxproj
@@ -575,6 +575,7 @@
 		AB6AE0C51CF7D6A700708654 /* Courses */ = {
 			isa = PBXGroup;
 			children = (
+				7E5C55701B4D32B3004DCDC7 /* CourseOverviewViewController.swift */,
 				AB91F9DF1CECB1A300007D06 /* CourseContentTableViewController.swift */,
 				AB91F9E41CED029B00007D06 /* CourseContentTableViewCell.swift */,
 				AB9AF2CC1CF3480E00ED3EB0 /* VideoViewController.swift */,
@@ -641,7 +642,6 @@
 			isa = PBXGroup;
 			children = (
 				F80D678A1B95909100E27520 /* CourseOverviewTabBarController.swift */,
-				7E5C55701B4D32B3004DCDC7 /* CourseOverviewViewController.swift */,
 				F89473C11B3C46FD00553882 /* RegisterViewController.swift */,
 			);
 			name = Main;

--- a/xikolo-ios/Base.lproj/Main.storyboard
+++ b/xikolo-ios/Base.lproj/Main.storyboard
@@ -1,28 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="JT0-zP-JnM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="vmi-wr-Zk6">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
-        <!--Navigation Controller-->
-        <scene sceneID="2RZ-rl-Bbn">
-            <objects>
-                <navigationController id="JT0-zP-JnM" sceneMemberID="viewController">
-                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="AvP-nJ-wnB">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="vmi-wr-Zk6" kind="relationship" relationship="rootViewController" id="5Ne-Ft-EcR"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="1nJ-tE-9vr" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="937" y="-328"/>
-        </scene>
         <!--Login-->
         <scene sceneID="LFp-Jf-nC8">
             <objects>
@@ -228,40 +211,40 @@
             </objects>
             <point key="canvasLocation" x="2404" y="-1077"/>
         </scene>
-        <!--CourseOverviewViewController-->
+        <!--CoursesNavigationController-->
         <scene sceneID="yCL-cx-d71">
             <objects>
-                <viewControllerPlaceholder storyboardIdentifier="CourseOverviewViewController" storyboardName="TabCourses" referencedIdentifier="CourseOverviewViewController" id="FSh-io-GSz" sceneMemberID="viewController">
+                <viewControllerPlaceholder storyboardIdentifier="CoursesNavigationController" storyboardName="TabCourses" referencedIdentifier="CoursesNavigationController" id="FSh-io-GSz" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Item" id="QnH-9R-uNS"/>
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aAB-Wq-oPw" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2394" y="-459"/>
         </scene>
-        <!--NewsViewController-->
+        <!--NewsNavigationController-->
         <scene sceneID="ybp-Ei-DDc">
             <objects>
-                <viewControllerPlaceholder storyboardIdentifier="NewsViewController" storyboardName="TabNews" referencedIdentifier="NewsViewController" id="XcO-jX-Il5" sceneMemberID="viewController">
+                <viewControllerPlaceholder storyboardIdentifier="NewsNavigationController" storyboardName="TabNews" referencedIdentifier="NewsNavigationController" id="XcO-jX-Il5" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Item" id="k4P-wb-7dX"/>
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mY7-MI-Wek" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2394.5" y="-328"/>
         </scene>
-        <!--DashboardViewController-->
+        <!--DashboardNavigationController-->
         <scene sceneID="wQX-9l-R5D">
             <objects>
-                <viewControllerPlaceholder storyboardIdentifier="DashboardViewController" storyboardName="TabDashboard" referencedIdentifier="DashboardViewController" id="4IQ-dc-5NS" sceneMemberID="viewController">
+                <viewControllerPlaceholder storyboardIdentifier="DashboardNavigationController" storyboardName="TabDashboard" referencedIdentifier="DashboardNavigationController" id="4IQ-dc-5NS" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Item" id="Dep-Da-lvB"/>
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7jy-pZ-fyz" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2394" y="-614"/>
         </scene>
-        <!--ProfileViewController-->
+        <!--ProfileNavigationController-->
         <scene sceneID="w9f-ev-CqT">
             <objects>
-                <viewControllerPlaceholder storyboardIdentifier="ProfileViewController" storyboardName="TabProfile" referencedIdentifier="ProfileViewController" id="qPo-RG-mu4" sceneMemberID="viewController">
+                <viewControllerPlaceholder storyboardIdentifier="ProfileNavigationController" storyboardName="TabProfile" referencedIdentifier="ProfileNavigationController" id="qPo-RG-mu4" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Item" id="HAW-UO-Q11"/>
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="KDU-l6-XvK" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/xikolo-ios/Base.lproj/TabCourses.storyboard
+++ b/xikolo-ios/Base.lproj/TabCourses.storyboard
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="uLl-5G-DMn">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="krt-FK-dfi">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
-        <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <scenes>
-        <!--Courses-->
+        <!--Course Overview View Controller-->
         <scene sceneID="aYm-tI-rNT">
             <objects>
                 <collectionViewController storyboardIdentifier="CourseOverviewViewController" id="uLl-5G-DMn" customClass="CourseOverviewViewController" customModule="xikolo_ios" customModuleProvider="target" sceneMemberID="viewController">
@@ -120,7 +119,6 @@
                             <outlet property="delegate" destination="uLl-5G-DMn" id="r9b-Z8-ClD"/>
                         </connections>
                     </collectionView>
-                    <tabBarItem key="tabBarItem" title="Courses" image="TabBarIconCourses" selectedImage="TabBarIconCoursesSelected" id="fhC-LU-HI2"/>
                     <navigationItem key="navigationItem" id="feQ-Xn-WIz">
                         <nil key="title"/>
                         <segmentedControl key="titleView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="CXl-G3-ErQ">
@@ -137,7 +135,7 @@
                 </collectionViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="i9p-Zg-3vF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2986" y="-943"/>
+            <point key="canvasLocation" x="3798" y="-943"/>
         </scene>
         <!--Course Content Table View Controller-->
         <scene sceneID="XFj-pH-TxF">
@@ -226,7 +224,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6rj-3l-8gO" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3778" y="-943"/>
+            <point key="canvasLocation" x="4590" y="-943"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="M4d-6f-bqM">
@@ -312,7 +310,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yh9-YM-hqK">
-                                <rect key="frame" x="0.0" y="56" width="600" height="495"/>
+                                <rect key="frame" x="0.0" y="64" width="600" height="487"/>
                                 <color key="backgroundColor" red="0.95927601809954743" green="0.95927601809954743" blue="0.95927601809954743" alpha="1" colorSpace="calibratedRGB"/>
                             </webView>
                         </subviews>
@@ -332,7 +330,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iTA-nh-Qzk" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4655" y="-1112"/>
+            <point key="canvasLocation" x="5467" y="-1112"/>
         </scene>
         <!--VideoViewController-->
         <scene sceneID="Zbn-mr-shH">
@@ -419,7 +417,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fOY-fk-G0c" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4655" y="-392"/>
+            <point key="canvasLocation" x="5467" y="-392"/>
         </scene>
         <!--AV Player View Controller-->
         <scene sceneID="Tl3-1b-ctw">
@@ -428,6 +426,25 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="6bD-81-FHE" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="5465" y="-392"/>
+        </scene>
+        <!--Courses-->
+        <scene sceneID="O7e-6a-qIC">
+            <objects>
+                <navigationController storyboardIdentifier="CoursesNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="krt-FK-dfi" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Courses" image="TabBarIconCourses" selectedImage="TabBarIconCoursesSelected" id="fhC-LU-HI2"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="aYN-LP-p0K">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="uLl-5G-DMn" kind="relationship" relationship="rootViewController" id="aFG-8h-93v"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="1wb-oK-Vy4" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2986" y="-943"/>
         </scene>
     </scenes>
     <resources>

--- a/xikolo-ios/Base.lproj/TabCourses.storyboard
+++ b/xikolo-ios/Base.lproj/TabCourses.storyboard
@@ -125,8 +125,8 @@
                             <rect key="frame" x="180" y="7" width="240" height="30"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <segments>
-                                <segment title="First"/>
-                                <segment title="Second"/>
+                                <segment title="All Courses"/>
+                                <segment title="My Courses"/>
                             </segments>
                         </segmentedControl>
                     </navigationItem>
@@ -297,10 +297,10 @@
             </objects>
             <point key="canvasLocation" x="4655" y="-1828"/>
         </scene>
-        <!--QuizWebviewController-->
+        <!--Quiz Web View Controller-->
         <scene sceneID="m7r-16-ntP">
             <objects>
-                <viewController storyboardIdentifier="QuizWebViewController" title="QuizWebviewController" id="qTX-IX-O1x" customClass="QuizWebViewController" customModule="xikolo_ios" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="QuizWebViewController" id="qTX-IX-O1x" customClass="QuizWebViewController" customModule="xikolo_ios" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="NZW-dL-rfb"/>
                         <viewControllerLayoutGuide type="bottom" id="1e2-yo-2eV"/>
@@ -332,10 +332,10 @@
             </objects>
             <point key="canvasLocation" x="5467" y="-1112"/>
         </scene>
-        <!--VideoViewController-->
+        <!--Video View Controller-->
         <scene sceneID="Zbn-mr-shH">
             <objects>
-                <viewController storyboardIdentifier="VideoViewController" title="VideoViewController" id="5Hh-M9-wy1" customClass="VideoViewController" customModule="xikolo_ios" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="VideoViewController" id="5Hh-M9-wy1" customClass="VideoViewController" customModule="xikolo_ios" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="ztS-j3-2Jk"/>
                         <viewControllerLayoutGuide type="bottom" id="eoR-na-C9E"/>

--- a/xikolo-ios/Base.lproj/TabDashboard.storyboard
+++ b/xikolo-ios/Base.lproj/TabDashboard.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="xXY-iO-myQ">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="hvL-LF-B6i">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
-        <!--Dashboard-->
+        <!--Dashboard View Controller-->
         <scene sceneID="z86-wG-GKj">
             <objects>
                 <viewController storyboardIdentifier="DashboardViewController" id="xXY-iO-myQ" customClass="DashboardViewController" customModule="xikolo_ios" customModuleProvider="target" sceneMemberID="viewController">
@@ -104,7 +104,7 @@
                             <constraint firstItem="29g-rN-RnC" firstAttribute="leading" secondItem="UZR-a1-eyw" secondAttribute="leading" id="xnT-Sd-BFB"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Dashboard" image="TabBarIconDashboard" selectedImage="TabBarIconDashboardSelected" id="eqp-FY-Bn8"/>
+                    <navigationItem key="navigationItem" id="AcW-uJ-dOa"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
@@ -115,6 +115,25 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7Rg-YL-Fie" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3365" y="-975"/>
+        </scene>
+        <!--Dashboard-->
+        <scene sceneID="TWB-cd-P4n">
+            <objects>
+                <navigationController storyboardIdentifier="DashboardNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="hvL-LF-B6i" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Dashboard" image="TabBarIconDashboard" selectedImage="TabBarIconDashboardSelected" id="eqp-FY-Bn8"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="m42-qA-Z45">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="xXY-iO-myQ" kind="relationship" relationship="rootViewController" id="dLU-7l-mMu"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="nBy-Si-jw7" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2553" y="-975"/>
         </scene>

--- a/xikolo-ios/Base.lproj/TabDashboard.storyboard
+++ b/xikolo-ios/Base.lproj/TabDashboard.storyboard
@@ -4,7 +4,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
-        <!--Dashboard View Controller-->
+        <!--Dashboard-->
         <scene sceneID="z86-wG-GKj">
             <objects>
                 <viewController storyboardIdentifier="DashboardViewController" id="xXY-iO-myQ" customClass="DashboardViewController" customModule="xikolo_ios" customModuleProvider="target" sceneMemberID="viewController">
@@ -104,7 +104,7 @@
                             <constraint firstItem="29g-rN-RnC" firstAttribute="leading" secondItem="UZR-a1-eyw" secondAttribute="leading" id="xnT-Sd-BFB"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="AcW-uJ-dOa"/>
+                    <navigationItem key="navigationItem" title="Dashboard" id="AcW-uJ-dOa"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>

--- a/xikolo-ios/Base.lproj/TabProfile.storyboard
+++ b/xikolo-ios/Base.lproj/TabProfile.storyboard
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BgN-Oc-elr">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="OO5-iD-7Qh">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <scenes>
-        <!--Profile-->
+        <!--Profile View Controller-->
         <scene sceneID="wo9-Tx-TCQ">
             <objects>
                 <viewController storyboardIdentifier="ProfileViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="BgN-Oc-elr" customClass="ProfileViewController" customModule="xikolo_ios" customModuleProvider="target" sceneMemberID="viewController">
@@ -118,7 +118,7 @@
                             <constraint firstItem="8gS-cM-lr5" firstAttribute="width" secondItem="Tff-pa-10z" secondAttribute="width" id="vPz-4T-eQu"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Profile" image="TabBarIconUser" selectedImage="TabBarIconUserSelected" id="r8t-cE-qA4"/>
+                    <navigationItem key="navigationItem" id="jbm-65-XMz"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
@@ -130,7 +130,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="L8d-hM-D9u" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2898" y="780"/>
+            <point key="canvasLocation" x="3710" y="780"/>
         </scene>
         <!--Table View Controller-->
         <scene sceneID="p6v-zt-3Vp">
@@ -305,7 +305,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Gx7-eb-Rf6" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3714" y="780.5"/>
+            <point key="canvasLocation" x="4526" y="780"/>
         </scene>
         <!--Edit Profile Settings View Controller-->
         <scene sceneID="por-kn-9Ch">
@@ -351,7 +351,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VqA-WW-QRs" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4442" y="1353"/>
+            <point key="canvasLocation" x="5254" y="1353"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="7dT-BL-Mvy">
@@ -370,7 +370,26 @@
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gym-2W-VDu" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3714" y="1353"/>
+            <point key="canvasLocation" x="4526" y="1353"/>
+        </scene>
+        <!--Profile-->
+        <scene sceneID="DLf-bN-3Fj">
+            <objects>
+                <navigationController storyboardIdentifier="ProfileNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="OO5-iD-7Qh" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Profile" image="TabBarIconUser" selectedImage="TabBarIconUserSelected" id="r8t-cE-qA4"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="KYe-EY-bH9">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BgN-Oc-elr" kind="relationship" relationship="rootViewController" id="6Sp-0r-sHU"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="uK3-u3-KCH" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2898" y="780"/>
         </scene>
     </scenes>
     <resources>

--- a/xikolo-ios/Base.lproj/TabProfile.storyboard
+++ b/xikolo-ios/Base.lproj/TabProfile.storyboard
@@ -6,7 +6,7 @@
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
     </dependencies>
     <scenes>
-        <!--Profile View Controller-->
+        <!--Profile-->
         <scene sceneID="wo9-Tx-TCQ">
             <objects>
                 <viewController storyboardIdentifier="ProfileViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="BgN-Oc-elr" customClass="ProfileViewController" customModule="xikolo_ios" customModuleProvider="target" sceneMemberID="viewController">
@@ -118,7 +118,7 @@
                             <constraint firstItem="8gS-cM-lr5" firstAttribute="width" secondItem="Tff-pa-10z" secondAttribute="width" id="vPz-4T-eQu"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="jbm-65-XMz"/>
+                    <navigationItem key="navigationItem" title="Profile" id="jbm-65-XMz"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>

--- a/xikolo-ios/CourseContentTableViewController.swift
+++ b/xikolo-ios/CourseContentTableViewController.swift
@@ -20,6 +20,9 @@ class CourseContentTableViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        navigationItem.title = course.name
+
         let request = CourseItemHelper.getItemRequest(course)
         resultsController = CourseItemHelper.initializeItemResultsController(request)
         resultsController.delegate = self

--- a/xikolo-ios/CourseOverviewViewController.swift
+++ b/xikolo-ios/CourseOverviewViewController.swift
@@ -23,10 +23,6 @@ class CourseOverviewViewController: AbstractCourseListViewController {
         super.viewDidLoad()
     }
     
-    override func viewDidAppear(animated: Bool) {
-        self.tabBarController!.title = NSLocalizedString("tab_courses", comment: "All Courses")
-    }
-    
     internal func showMyCoursesOnly(showMyCourses: Bool) {
         self.courseDisplayMode = showMyCourses ? .EnrolledOnly : .All
     }

--- a/xikolo-ios/DashboardViewController.swift
+++ b/xikolo-ios/DashboardViewController.swift
@@ -15,10 +15,6 @@ class DashboardViewController: UIViewController, UIWebViewDelegate {
     @IBOutlet weak var deadlinesActivityIndicator: UIActivityIndicatorView!
     @IBOutlet weak var notificationsActivityIndicator: UIActivityIndicatorView!
     
-    override func viewDidAppear(animated: Bool) {
-        self.tabBarController!.title = NSLocalizedString("tab_dashboard", comment: "Dashboard")
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         loadDeadlinesWebView()

--- a/xikolo-ios/NewsViewController.swift
+++ b/xikolo-ios/NewsViewController.swift
@@ -39,10 +39,6 @@ class NewsViewController: UIViewController, UIWebViewDelegate{
         self.webViewNews.loadRequest(NetworkHelper.getRequestForURL(url))
     }
     
-    override func viewDidAppear(animated: Bool) {
-        self.tabBarController!.title = NSLocalizedString("tab_news", comment: "News")
-    }
-    
     func webViewDidStartLoad(webView: UIWebView) {
         activityIndicator.startAnimating()
         self.view.addSubview(activityIndicator)

--- a/xikolo-ios/ProfileViewController.swift
+++ b/xikolo-ios/ProfileViewController.swift
@@ -38,10 +38,6 @@ class ProfileViewController: UIViewController {
         relayout()
     }
     
-    override func viewDidAppear(animated: Bool) {
-        self.tabBarController!.title = NSLocalizedString("tab_profile", comment: "Profile")
-    }
-    
     func setupViews() {
         self.profileImage.layer.cornerRadius = self.profileImage.frame.size.width / 2;
         self.profileImage.clipsToBounds = true;

--- a/xikolo-ios/TabNews.storyboard
+++ b/xikolo-ios/TabNews.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="rQe-Ua-e4E">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="hJj-vh-sHE">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
-        <!--News-->
+        <!--News View Controller-->
         <scene sceneID="hXl-aj-vOT">
             <objects>
                 <viewController storyboardIdentifier="NewsViewController" id="rQe-Ua-e4E" customClass="NewsViewController" customModule="xikolo_ios" customModuleProvider="target" sceneMemberID="viewController">
@@ -49,7 +49,6 @@
                             </mask>
                         </variation>
                     </view>
-                    <tabBarItem key="tabBarItem" title="News" image="TabBarIconNews" selectedImage="TabBarIconNewsSelected" id="Iok-ZF-Mpk"/>
                     <navigationItem key="navigationItem" id="dRl-af-QvE">
                         <nil key="title"/>
                     </navigationItem>
@@ -61,6 +60,25 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="kVr-QZ-VIe" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3844" y="160"/>
+        </scene>
+        <!--News-->
+        <scene sceneID="a7D-B7-NgZ">
+            <objects>
+                <navigationController storyboardIdentifier="NewsNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="hJj-vh-sHE" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="News" image="TabBarIconNews" selectedImage="TabBarIconNewsSelected" id="Iok-ZF-Mpk"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Rgc-ev-Ao6">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="rQe-Ua-e4E" kind="relationship" relationship="rootViewController" id="OGu-Gg-tEE"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vKM-5D-Ir5" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="3032" y="160"/>
         </scene>

--- a/xikolo-ios/TabNews.storyboard
+++ b/xikolo-ios/TabNews.storyboard
@@ -51,6 +51,14 @@
                     </view>
                     <navigationItem key="navigationItem" id="dRl-af-QvE">
                         <nil key="title"/>
+                        <segmentedControl key="titleView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="bar" selectedSegmentIndex="0" id="ytp-SX-B4p">
+                            <rect key="frame" x="180" y="7" width="240" height="30"/>
+                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <segments>
+                                <segment title="News"/>
+                                <segment title="Course Activity"/>
+                            </segments>
+                        </segmentedControl>
                     </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>


### PR DESCRIPTION
Refactored Storyboards to solve some major problems, mainly regarding the title zone in the navigation bar. It also helps preserving states across tabs.

I achieved it by creating a separate NavigationsController as the root ViewController for every tab instead of one as a parent of the TabBarController.