### PR TITLE
Add version number to commit message on build number increment.

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,8 +19,9 @@ platform :ios do
   desc "Increments the build number for all targets"
   lane :increment_build do
     new_build_number = increment_build_number
+    version_number = get_version_number
     commit_version_bump(
-      message: "Bump build number to #{new_build_number}."
+      message: "Bump build number to #{new_build_number} (version #{version_number})."
     )
   end
 


### PR DESCRIPTION
To get a reference of the current version.