### PR TITLE
Handle build numbers automatically

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,6 +58,57 @@ platform :ios do
     )
   end
 
+  desc "Determines the commit for a given build number"
+  desc "- pass build number via 'build_number:xxx'"
+  lane :determine_commit do |options|
+    if options[:build_number]
+      build_components = options[:build_number].split(".")
+      if build_components.length == 1
+        commit_count = build_components[0].to_i
+        branch_name = "master"
+      elsif build_components.length == 2
+        commit_count = build_components[0].to_i
+        if build_components[1] == "0"
+          branch_name = "develop"
+        else
+          UI.user_error! "Detected feature branch build. Only builds from `master` or `develop` are supported."
+        end
+      else
+        UI.user_error! "Supplied malformed build number"
+      end
+
+      puts "Branch: #{branch_name}"
+      puts "Commit count: #{commit_count}"
+
+      error_callback = proc do |error|
+        UI.user_error! "Branch `#{branch_name}` does not exist."
+      end
+      sh("git rev-parse --verify #{branch_name}", error_callback: error_callback)
+
+      total_commit_count = sh("git rev-list #{branch_name} | wc -l | sed 's/^ *//;s/ *$//'").to_i
+      puts "Total commit count on #{branch_name}: #{total_commit_count}"
+
+      commit_count_diff = total_commit_count - commit_count
+      puts "Commit count difference: #{commit_count_diff}"
+
+      if commit_count_diff < 0
+        UI.user_error! "Supplied refers to a commit which is to far ahead"
+      end
+
+      commit_id = sh("git rev-parse --short head~#{commit_count_diff}").strip!
+      commit_title = sh("git log #{commit_id} --pretty=format:'%s' --max-count=1")
+      commit_author = sh("git log #{commit_id} --pretty=format:'%an' --max-count=1")
+
+      UI.header "Found commit for build_number #{options[:build_number]}"
+      UI.success "Branch: #{branch_name}"
+      UI.success "Commit id: #{commit_id}"
+      UI.success "Commit title: #{commit_title}"
+      UI.success "Commit author: #{commit_author}"
+    else
+      UI.user_error! "No build number supplied (use `fastlane determine_commit build_number:xxx`)"
+    end
+  end
+
   desc "Checks application for potential App Store violations"
   desc "- requires app environment via '--env'"
   lane :precheck_app do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,15 +16,6 @@ fastlane_version "2.55.0"
 default_platform :ios
 
 platform :ios do
-  desc "Increments the build number for all targets"
-  lane :increment_build do
-    new_build_number = increment_build_number
-    version_number = get_version_number
-    commit_version_bump(
-      message: "Bump build number to #{new_build_number} (version #{version_number})."
-    )
-  end
-
   desc "Increments the version number for a new patch version"
   lane :increment_version_patch do
     new_version_number = increment_version_number(
@@ -32,7 +23,7 @@ platform :ios do
     )
     revert_tvOS_changes()
     commit_version_bump(
-      message: "New version #{new_version_number} (patch)."
+      message: "New version #{new_version_number}"
     )
   end
 
@@ -43,7 +34,7 @@ platform :ios do
     )
     revert_tvOS_changes()
     commit_version_bump(
-      message: "New version #{new_version_number} (minor)."
+      message: "New version #{new_version_number}"
     )
   end
 
@@ -54,7 +45,7 @@ platform :ios do
     )
     revert_tvOS_changes()
     commit_version_bump(
-      message: "New version #{new_version_number} (major)."
+      message: "New version #{new_version_number}"
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,12 +58,12 @@ platform :ios do
         commit_count = build_components[0].to_i
         branch_name = "master"
       elsif build_components.length == 2
-        commit_count = build_components[1].to_i
-        if build_components[0] == "0"
-          branch_name = "dev"
-        else
-          UI.user_error! "Detected feature branch build. Only builds from `master` or `dev` are supported."
-        end
+        commit_count_master = build_components[0].to_i
+        commit_count_dev_diff = build_components[1].to_i
+        commit_count = commit_count_master + commit_count_dev_diff
+        branch_name = "dev"
+      elsif build_components.length == 3
+        UI.user_error! "Detected feature branch build. Only builds from `master` or `dev` are supported."
       else
         UI.user_error! "Supplied malformed build number"
       end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -58,11 +58,11 @@ platform :ios do
         commit_count = build_components[0].to_i
         branch_name = "master"
       elsif build_components.length == 2
-        commit_count = build_components[0].to_i
-        if build_components[1] == "0"
-          branch_name = "develop"
+        commit_count = build_components[1].to_i
+        if build_components[0] == "0"
+          branch_name = "dev"
         else
-          UI.user_error! "Detected feature branch build. Only builds from `master` or `develop` are supported."
+          UI.user_error! "Detected feature branch build. Only builds from `master` or `dev` are supported."
         end
       else
         UI.user_error! "Supplied malformed build number"

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -30,11 +30,6 @@ xcode-select --install
 
 # Available Actions
 ## iOS
-### ios increment_build
-```
-fastlane ios increment_build
-```
-Increments the build number for all targets
 ### ios increment_version_patch
 ```
 fastlane ios increment_version_patch
@@ -50,13 +45,6 @@ Increments the version number for a new minor version
 fastlane ios increment_version_major
 ```
 Increments the version number for a new major version
-### ios precheck_app
-```
-fastlane ios precheck_app
-```
-Checks application for potential App Store violations
-
-- requires app environment via '--env'
 ### ios determine_commit
 ```
 fastlane ios determine_commit
@@ -64,6 +52,13 @@ fastlane ios determine_commit
 Determines the commit for a given build number
 
 - pass build number via 'build_number:xxx'
+### ios precheck_app
+```
+fastlane ios precheck_app
+```
+Checks application for potential App Store violations
+
+- requires app environment via '--env'
 ### ios localize
 ```
 fastlane ios localize

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -57,6 +57,13 @@ fastlane ios precheck_app
 Checks application for potential App Store violations
 
 - requires app environment via '--env'
+### ios determine_commit
+```
+fastlane ios determine_commit
+```
+Determines the commit for a given build number
+
+- pass build number via 'build_number:xxx'
 ### ios localize
 ```
 fastlane ios localize

--- a/xikolo-ios.xcodeproj/project.pbxproj
+++ b/xikolo-ios.xcodeproj/project.pbxproj
@@ -2860,12 +2860,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 24BA40431D3F976800E38C2C /* Build configuration list for PBXNativeTarget "openSAP-iOS" */;
 			buildPhases = (
+				50429D9A1FB07288000C1D5E /* Set Build Number */,
 				7919434A264A33D8AF707163 /* [CP] Check Pods Manifest.lock */,
 				24BA40301D3F976700E38C2C /* Sources */,
 				24BA40311D3F976700E38C2C /* Frameworks */,
 				24BA40321D3F976700E38C2C /* Resources */,
 				A37F6E838D362B6B9C45D6FD /* [CP] Embed Pods Frameworks */,
 				747AA6185FE4F61F6B113EC5 /* [CP] Copy Pods Resources */,
+				50429D9B1FB0728C000C1D5E /* Clear Build Number */,
 			);
 			buildRules = (
 			);
@@ -2943,12 +2945,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 709C93121EF0952500F8F045 /* Build configuration list for PBXNativeTarget "moocHOUSE-iOS" */;
 			buildPhases = (
+				50429D9E1FB072D3000C1D5E /* Set Build Number */,
 				0089F3364BA801A526B4D83B /* [CP] Check Pods Manifest.lock */,
 				709C92FF1EF0952500F8F045 /* Sources */,
 				709C93001EF0952500F8F045 /* Frameworks */,
 				709C93011EF0952500F8F045 /* Resources */,
 				64BDA7A093734A38DD163B71 /* [CP] Embed Pods Frameworks */,
 				1F57239A56A003CFD9A17C49 /* [CP] Copy Pods Resources */,
+				50429D9F1FB072D5000C1D5E /* Clear Build Number */,
 			);
 			buildRules = (
 			);
@@ -3004,12 +3008,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A90587E31B3BFC130095DB89 /* Build configuration list for PBXNativeTarget "openHPI-iOS" */;
 			buildPhases = (
+				50429D981FB070E4000C1D5E /* Set Build Number */,
 				675F726F01CFB36A8F89AFBE /* [CP] Check Pods Manifest.lock */,
 				A90587B71B3BFC130095DB89 /* Sources */,
 				A90587B81B3BFC130095DB89 /* Frameworks */,
 				A90587B91B3BFC130095DB89 /* Resources */,
 				4F0AA42C7F773EF30322D506 /* [CP] Embed Pods Frameworks */,
 				AC51BF7E1DD4B0B165B5B82B /* [CP] Copy Pods Resources */,
+				50429D991FB07149000C1D5E /* Clear Build Number */,
 			);
 			buildRules = (
 			);
@@ -3024,12 +3030,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = AB48B4461DF8BB2A00523062 /* Build configuration list for PBXNativeTarget "openWHO-iOS" */;
 			buildPhases = (
+				50429D9C1FB072AD000C1D5E /* Set Build Number */,
 				E4366C3C332640BAB19B0552 /* [CP] Check Pods Manifest.lock */,
 				AB48B4311DF8BB2A00523062 /* Sources */,
 				AB48B4321DF8BB2A00523062 /* Frameworks */,
 				AB48B4331DF8BB2A00523062 /* Resources */,
 				ACB757C47A664C44D01683E8 /* [CP] Embed Pods Frameworks */,
 				99A701B933A853760C844333 /* [CP] Copy Pods Resources */,
+				50429D9D1FB072AE000C1D5E /* Clear Build Number */,
 			);
 			buildRules = (
 			);
@@ -3692,6 +3700,118 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		50429D981FB070E4000C1D5E /* Set Build Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Set Build Number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_suffix=\"\"\nif [ \"$branch_name\" == \"develop\" ]; then\n  build_suffix=\".0\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_suffix=\".1\"\n  fi\nfi\nbuild_number=\"$git_count$build_suffix\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
+		};
+		50429D991FB07149000C1D5E /* Clear Build Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Clear Build Number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion 0\" \"${PRODUCT_SETTINGS_PATH}\"\necho \"Cleared build number in ${PRODUCT_SETTINGS_PATH}\"";
+		};
+		50429D9A1FB07288000C1D5E /* Set Build Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Set Build Number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_suffix=\"\"\nif [ \"$branch_name\" == \"develop\" ]; then\n  build_suffix=\".0\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_suffix=\".1\"\n  fi\nfi\nbuild_number=\"$git_count$build_suffix\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
+		};
+		50429D9B1FB0728C000C1D5E /* Clear Build Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Clear Build Number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion 0\" \"${PRODUCT_SETTINGS_PATH}\"\necho \"Cleared build number in ${PRODUCT_SETTINGS_PATH}\"";
+		};
+		50429D9C1FB072AD000C1D5E /* Set Build Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Set Build Number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_suffix=\"\"\nif [ \"$branch_name\" == \"develop\" ]; then\n  build_suffix=\".0\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_suffix=\".1\"\n  fi\nfi\nbuild_number=\"$git_count$build_suffix\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
+		};
+		50429D9D1FB072AE000C1D5E /* Clear Build Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Clear Build Number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion 0\" \"${PRODUCT_SETTINGS_PATH}\"\necho \"Cleared build number in ${PRODUCT_SETTINGS_PATH}\"";
+		};
+		50429D9E1FB072D3000C1D5E /* Set Build Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Set Build Number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_suffix=\"\"\nif [ \"$branch_name\" == \"develop\" ]; then\n  build_suffix=\".0\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_suffix=\".1\"\n  fi\nfi\nbuild_number=\"$git_count$build_suffix\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
+		};
+		50429D9F1FB072D5000C1D5E /* Clear Build Number */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Clear Build Number";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion 0\" \"${PRODUCT_SETTINGS_PATH}\"\necho \"Cleared build number in ${PRODUCT_SETTINGS_PATH}\"";
 		};
 		57CD7946E155D5BFDF1EE5AC /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/xikolo-ios.xcodeproj/project.pbxproj
+++ b/xikolo-ios.xcodeproj/project.pbxproj
@@ -3713,7 +3713,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_suffix=\"\"\nif [ \"$branch_name\" == \"develop\" ]; then\n  build_suffix=\".0\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_suffix=\".1\"\n  fi\nfi\nbuild_number=\"$git_count$build_suffix\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
+			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_prefix=\"\"\nif [ \"$branch_name\" == \"dev\" ]; then\n  build_prefix=\"0.\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_prefix=\"1.\"\n  fi\nfi\nbuild_number=\"$build_prefix$git_count\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
 		};
 		50429D991FB07149000C1D5E /* Clear Build Number */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3741,7 +3741,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_suffix=\"\"\nif [ \"$branch_name\" == \"develop\" ]; then\n  build_suffix=\".0\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_suffix=\".1\"\n  fi\nfi\nbuild_number=\"$git_count$build_suffix\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
+			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_prefix=\"\"\nif [ \"$branch_name\" == \"dev\" ]; then\n  build_prefix=\"0.\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_prefix=\"1.\"\n  fi\nfi\nbuild_number=\"$build_prefix$git_count\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
 		};
 		50429D9B1FB0728C000C1D5E /* Clear Build Number */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3769,7 +3769,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_suffix=\"\"\nif [ \"$branch_name\" == \"develop\" ]; then\n  build_suffix=\".0\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_suffix=\".1\"\n  fi\nfi\nbuild_number=\"$git_count$build_suffix\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
+			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_prefix=\"\"\nif [ \"$branch_name\" == \"dev\" ]; then\n  build_prefix=\"0.\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_prefix=\"1.\"\n  fi\nfi\nbuild_number=\"$build_prefix$git_count\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
 		};
 		50429D9D1FB072AE000C1D5E /* Clear Build Number */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3797,7 +3797,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_suffix=\"\"\nif [ \"$branch_name\" == \"develop\" ]; then\n  build_suffix=\".0\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_suffix=\".1\"\n  fi\nfi\nbuild_number=\"$git_count$build_suffix\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
+			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_prefix=\"\"\nif [ \"$branch_name\" == \"dev\" ]; then\n  build_prefix=\"0.\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_prefix=\"1.\"\n  fi\nfi\nbuild_number=\"$build_prefix$git_count\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
 		};
 		50429D9F1FB072D5000C1D5E /* Clear Build Number */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/xikolo-ios.xcodeproj/project.pbxproj
+++ b/xikolo-ios.xcodeproj/project.pbxproj
@@ -3713,7 +3713,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_prefix=\"\"\nif [ \"$branch_name\" == \"dev\" ]; then\n  build_prefix=\"0.\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_prefix=\"1.\"\n  fi\nfi\nbuild_number=\"$build_prefix$git_count\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
+			shellScript = "git=`sh /etc/profile; which git`\nmerge_base=`$git merge-base master HEAD`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ncommit_count_merge_base=`$git rev-list --count $merge_base`\ncommit_count_diff_head=`$git rev-list --count $merge_base..HEAD`\n\nbuild_number=$commit_count_merge_base\nif [ \"$branch_name\" != \"master\" ]; then\n  build_number=\"$build_number.$commit_count_diff_head\"\n  if [ \"$branch_name\" != \"dev\" ]; then\n    build_number=\"$build_number.0\"\n  fi\nfi\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
 		};
 		50429D991FB07149000C1D5E /* Clear Build Number */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3741,7 +3741,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_prefix=\"\"\nif [ \"$branch_name\" == \"dev\" ]; then\n  build_prefix=\"0.\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_prefix=\"1.\"\n  fi\nfi\nbuild_number=\"$build_prefix$git_count\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
+			shellScript = "git=`sh /etc/profile; which git`\nmerge_base=`$git merge-base master HEAD`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ncommit_count_merge_base=`$git rev-list --count $merge_base`\ncommit_count_diff_head=`$git rev-list --count $merge_base..HEAD`\n\nbuild_number=$commit_count_merge_base\nif [ \"$branch_name\" != \"master\" ]; then\n  build_number=\"$build_number.$commit_count_diff_head\"\n  if [ \"$branch_name\" != \"dev\" ]; then\n    build_number=\"$build_number.0\"\n  fi\nfi\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
 		};
 		50429D9B1FB0728C000C1D5E /* Clear Build Number */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3769,7 +3769,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_prefix=\"\"\nif [ \"$branch_name\" == \"dev\" ]; then\n  build_prefix=\"0.\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_prefix=\"1.\"\n  fi\nfi\nbuild_number=\"$build_prefix$git_count\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
+			shellScript = "git=`sh /etc/profile; which git`\nmerge_base=`$git merge-base master HEAD`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ncommit_count_merge_base=`$git rev-list --count $merge_base`\ncommit_count_diff_head=`$git rev-list --count $merge_base..HEAD`\n\nbuild_number=$commit_count_merge_base\nif [ \"$branch_name\" != \"master\" ]; then\n  build_number=\"$build_number.$commit_count_diff_head\"\n  if [ \"$branch_name\" != \"dev\" ]; then\n    build_number=\"$build_number.0\"\n  fi\nfi\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
 		};
 		50429D9D1FB072AE000C1D5E /* Clear Build Number */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3797,7 +3797,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "git=`sh /etc/profile; which git`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ngit_count=`$git rev-list $branch_name | wc -l | sed 's/^ *//;s/ *$//'`\n\nbuild_prefix=\"\"\nif [ \"$branch_name\" == \"dev\" ]; then\n  build_prefix=\"0.\"\nelse\n  if [ \"$branch_name\" != \"master\" ]; then\n    build_prefix=\"1.\"\n  fi\nfi\nbuild_number=\"$build_prefix$git_count\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
+			shellScript = "git=`sh /etc/profile; which git`\nmerge_base=`$git merge-base master HEAD`\nbranch_name=`$git symbolic-ref HEAD | sed -e 's,.*/\\\\(.*\\\\),\\\\1,'`\ncommit_count_merge_base=`$git rev-list --count $merge_base`\ncommit_count_diff_head=`$git rev-list --count $merge_base..HEAD`\n\nbuild_number=$commit_count_merge_base\nif [ \"$branch_name\" != \"master\" ]; then\n  build_number=\"$build_number.$commit_count_diff_head\"\n  if [ \"$branch_name\" != \"dev\" ]; then\n    build_number=\"$build_number.0\"\n  fi\nfi\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $build_number\" \"${PRODUCT_SETTINGS_PATH}\"\n\necho \"Updated build number in ${PRODUCT_SETTINGS_PATH} to $build_number\"";
 		};
 		50429D9F1FB072D5000C1D5E /* Clear Build Number */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/xikolo-ios/Branding/moocHOUSE/Info.plist
+++ b/xikolo-ios/Branding/moocHOUSE/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/xikolo-ios/Branding/openHPI/Info.plist
+++ b/xikolo-ios/Branding/openHPI/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/xikolo-ios/Branding/openSAP/Info.plist
+++ b/xikolo-ios/Branding/openSAP/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/xikolo-ios/Branding/openWHO/Info.plist
+++ b/xikolo-ios/Branding/openWHO/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Fixes #400

### Proposed Changes:
- Base build numbers on git history (number of commits)
- Formats:
  - master: `[number of commits on master]`
  - dev: `[number of commits on master].[number of commits on dev ahead of master]`
  - feature: `[number of commits on master].[number of commits on dev ahead of master].0` (leading zero)
- Add fastlane command to find commit for build number (only for build on master or dev)
- Build numbers will not be commited via git (0 as default value)

### Open tasks:
- [ ] Create unprotected `dev` branch