### PR TITLE
Patch release to pin API version

### DIFF
--- a/xikolo-common/Data/Routes.swift
+++ b/xikolo-common/Data/Routes.swift
@@ -29,7 +29,7 @@ struct Routes {
     static let HEADER_USER_PLATFORM_VALUE = "iOS"
 
     static let HTTP_ACCEPT_HEADER = "Accept"
-    static let HTTP_ACCEPT_HEADER_VALUE = "application/vnd.xikolo.v1, application/json"
+    static let HTTP_ACCEPT_HEADER_VALUE = "application/vnd.api+json; xikolo-version=2"
     static let HTTP_AUTH_HEADER = "Authorization"
     static let HTTP_AUTH_HEADER_VALUE_PREFIX = "Token token="
 

--- a/xikolo-ios/Branding/moocHOUSE/Info.plist
+++ b/xikolo-ios/Branding/moocHOUSE/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.2</string>
+	<string>1.3.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/xikolo-ios/Branding/openHPI/Info.plist
+++ b/xikolo-ios/Branding/openHPI/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.2</string>
+	<string>1.3.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/xikolo-ios/Branding/openSAP/Info.plist
+++ b/xikolo-ios/Branding/openSAP/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.2</string>
+	<string>1.3.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/xikolo-ios/Branding/openWHO/Info.plist
+++ b/xikolo-ios/Branding/openWHO/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.2</string>
+	<string>1.3.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
We have to release a patch version of the current app which pins the API requests to API version 2 in order to prevent app crashes when API version 3 is released in the next days.

