### PR TITLE
Move synchronize to better place

### DIFF
--- a/xikolo-ios/AppDelegate.swift
+++ b/xikolo-ios/AppDelegate.swift
@@ -68,6 +68,7 @@ class AppDelegate : AbstractAppDelegate {
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
+        UserDefaults.standard.synchronize()
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }

--- a/xikolo-ios/Views/VideoPlayerControlView.swift
+++ b/xikolo-ios/Views/VideoPlayerControlView.swift
@@ -143,7 +143,6 @@ class VideoPlayerControlView: BMPlayerControlView {
         }
 
         UserDefaults.standard.set(self.playRate, forKey: UserDefaultsKeys.playbackRateKey)
-        UserDefaults.standard.synchronize()
 
         self.updatePlaybackRateButton()
         self.delegate?.controlView?(controlView: self, didChangeVideoPlaybackRate: self.playRate)


### PR DESCRIPTION
Fixes #363 

### Proposed Changes:
I'm not sure wether this is worth the additional line in the Appdelegate. We could also just delete the line since
* it periodically gets saved by Apple
* we don't need it in another thread and
* if we crash shortly after setting the playback rate I think we have bigger problems than the possibly wrong speed in the next video view. 
At the same time I don't think the performance penalty even justifies thinking about this one line this long ;)