### PR TITLE
Add user action to mark as announcements as read

### DIFF
--- a/iOS/Base.lproj/Localizable.strings
+++ b/iOS/Base.lproj/Localizable.strings
@@ -1,4 +1,7 @@
 
+/* alert action title to mark all announcements as read */
+"announcement.alert.mark all as read" = "Mark all as read";
+
 /* App state message for deprecated API version */
 "app-state.api-deprecated.please update the %@ app before %@" = "Please update the %@ app before %@";
 

--- a/iOS/Storyboards/Base.lproj/TabNews.storyboard
+++ b/iOS/Storyboards/Base.lproj/TabNews.storyboard
@@ -143,10 +143,17 @@
                             <outlet property="delegate" destination="vxq-Ct-km1" id="axD-p1-lTo"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="News" id="ZnP-5l-3Ix"/>
+                    <navigationItem key="navigationItem" title="News" id="ZnP-5l-3Ix">
+                        <barButtonItem key="rightBarButtonItem" image="dots" id="Abn-bO-lDv">
+                            <connections>
+                                <action selector="tappedActionButton:" destination="vxq-Ct-km1" id="mM3-bB-oYe"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
+                        <outlet property="actionButton" destination="Abn-bO-lDv" id="22u-0J-hUq"/>
                         <segue destination="eQp-3j-Pq9" kind="show" identifier="ShowAnnouncement" id="8QI-od-mYg"/>
                     </connections>
                 </tableViewController>
@@ -297,6 +304,7 @@
         </scene>
     </scenes>
     <resources>
+        <image name="dots" width="28" height="28"/>
         <image name="tab bar items/news" width="25" height="25"/>
     </resources>
 </document>

--- a/iOS/ViewControllers/News/AnnouncementsListViewController.swift
+++ b/iOS/ViewControllers/News/AnnouncementsListViewController.swift
@@ -21,8 +21,17 @@ class AnnouncementsListViewController: UITableViewController {
 
     var course: Course?
 
+    @IBOutlet private var actionButton: UIBarButtonItem!
+
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(updateUIAfterLoginStateChanged),
+                                               name: UserProfileHelper.loginStateDidChangeNotification,
+                                               object: nil)
+
+        self.updateUIAfterLoginStateChanged()
 
         // setup pull to refresh
         let refreshControl = UIRefreshControl()
@@ -102,6 +111,24 @@ class AnnouncementsListViewController: UITableViewController {
         }
     }
 
+    @objc private func updateUIAfterLoginStateChanged() {
+        self.navigationItem.rightBarButtonItem = UserProfileHelper.shared.isLoggedIn ? self.actionButton : nil
+    }
+
+    @IBAction func tappedActionButton(_ sender: UIBarButtonItem) {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        alert.popoverPresentationController?.barButtonItem = sender
+
+        let markAllAsReadActionTitle = NSLocalizedString("announcement.alert.mark all as read", comment: "alert action title to mark all announcements as read")
+        let markAllAsReadAction = UIAlertAction(title: markAllAsReadActionTitle, style: .default) { _ in
+            AnnouncementHelper.shared.markAllAsVisited()
+        }
+
+        alert.addAction(markAllAsReadAction)
+        alert.addCancelAction()
+
+        self.present(alert, animated: true)
+    }
 }
 
 extension AnnouncementsListViewController { // TableViewDelegate

--- a/iOS/de.lproj/Localizable.strings
+++ b/iOS/de.lproj/Localizable.strings
@@ -1,4 +1,7 @@
 
+/* alert action title to mark all announcements as read */
+"announcement.alert.mark all as read" = "Alle als gelesen markieren";
+
 /* App state message for deprecated API version */
 "app-state.api-deprecated.please update the %@ app before %@" = "Bitte die %@-App vor %@ aktualisieren";
 


### PR DESCRIPTION
Fixes #90

### Proposed Changes:
- Add user action to mark as announcements as read
- Add action menu to announcement list (only visible when logged in)