### PR TITLE
Fix download names having the same file name

### DIFF
--- a/iOS/Helpers/PersistenceManager/FilePersistenceManager.swift
+++ b/iOS/Helpers/PersistenceManager/FilePersistenceManager.swift
@@ -36,7 +36,7 @@ extension FilePersistenceManager {
         guard let fileName = task.originalRequest?.url?.lastPathComponent else { return }
         guard let contentId = task.taskDescription else { return }
 
-        let documentLocation = documentsDirectory.appendingPathComponent(contentId + "_" + Self.downloadType + "_" + fileName)
+        let documentLocation = documentsDirectory.appendingPathComponent(Self.downloadType + "_" + contentId + "_" + fileName)
 
         do {
             if FileManager.default.fileExists(atPath: documentLocation.path) {

--- a/iOS/Helpers/PersistenceManager/FilePersistenceManager.swift
+++ b/iOS/Helpers/PersistenceManager/FilePersistenceManager.swift
@@ -34,8 +34,9 @@ extension FilePersistenceManager {
     func downloadTask(_ task: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last else { return }
         guard let fileName = task.originalRequest?.url?.lastPathComponent else { return }
+        guard let contentId = task.taskDescription else { return }
 
-        let documentLocation = documentsDirectory.appendingPathComponent(fileName)
+        let documentLocation = documentsDirectory.appendingPathComponent(contentId + "_" + Self.downloadType + "_" + fileName)
 
         do {
             if FileManager.default.fileExists(atPath: documentLocation.path) {


### PR DESCRIPTION
by including the course-item content UUID and the download type in the file name. This lead to only the last pdf being available if the file names were the same.

### Proposed Changes:
We could also change the filename when sharing the file from the PDFViewController. It currently features the UUID of the item and is pretty long. We could create a hardlink in the temp directory to avoid having to copy the file since there doesn't seem to be a way to rename the file before it is shared.