### PR TITLE
Show warnings for long compile times

### DIFF
--- a/Xcode Configurations/moocHOUSE/moocHOUSE-iOS-Debug.xcconfig
+++ b/Xcode Configurations/moocHOUSE/moocHOUSE-iOS-Debug.xcconfig
@@ -14,4 +14,4 @@ SWIFT_COMPILATION_MODE = singlefile
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 ENABLE_NS_ASSERTIONS = YES
 
-OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS" "-Xfrontend" "-warn-long-function-bodies=100" "-Xfrontend" "-warn-long-expression-type-checking=100"
+OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS" "-Xfrontend" "-warn-long-function-bodies=150" "-Xfrontend" "-warn-long-expression-type-checking=150"

--- a/Xcode Configurations/moocHOUSE/moocHOUSE-iOS-Debug.xcconfig
+++ b/Xcode Configurations/moocHOUSE/moocHOUSE-iOS-Debug.xcconfig
@@ -14,4 +14,4 @@ SWIFT_COMPILATION_MODE = singlefile
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 ENABLE_NS_ASSERTIONS = YES
 
-OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS"
+OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS" "-Xfrontend" "-warn-long-function-bodies=100" "-Xfrontend" "-warn-long-expression-type-checking=100"

--- a/Xcode Configurations/openHPI/openHPI-iOS-Debug.xcconfig
+++ b/Xcode Configurations/openHPI/openHPI-iOS-Debug.xcconfig
@@ -14,4 +14,4 @@ SWIFT_COMPILATION_MODE = singlefile
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 ENABLE_NS_ASSERTIONS = YES
 
-OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS" "-Xfrontend" "-warn-long-function-bodies=100" "-Xfrontend" "-warn-long-expression-type-checking=100"
+OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS" "-Xfrontend" "-warn-long-function-bodies=150" "-Xfrontend" "-warn-long-expression-type-checking=150"

--- a/Xcode Configurations/openHPI/openHPI-iOS-Debug.xcconfig
+++ b/Xcode Configurations/openHPI/openHPI-iOS-Debug.xcconfig
@@ -14,4 +14,4 @@ SWIFT_COMPILATION_MODE = singlefile
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 ENABLE_NS_ASSERTIONS = YES
 
-OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS"
+OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS" "-Xfrontend" "-warn-long-function-bodies=100" "-Xfrontend" "-warn-long-expression-type-checking=100"

--- a/Xcode Configurations/openSAP/openSAP-iOS-Debug.xcconfig
+++ b/Xcode Configurations/openSAP/openSAP-iOS-Debug.xcconfig
@@ -14,4 +14,4 @@ SWIFT_COMPILATION_MODE = singlefile
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 ENABLE_NS_ASSERTIONS = YES
 
-OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS" "-Xfrontend" "-warn-long-function-bodies=100" "-Xfrontend" "-warn-long-expression-type-checking=100"
+OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS" "-Xfrontend" "-warn-long-function-bodies=150" "-Xfrontend" "-warn-long-expression-type-checking=150"

--- a/Xcode Configurations/openSAP/openSAP-iOS-Debug.xcconfig
+++ b/Xcode Configurations/openSAP/openSAP-iOS-Debug.xcconfig
@@ -14,4 +14,4 @@ SWIFT_COMPILATION_MODE = singlefile
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 ENABLE_NS_ASSERTIONS = YES
 
-OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS"
+OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS" "-Xfrontend" "-warn-long-function-bodies=100" "-Xfrontend" "-warn-long-expression-type-checking=100"

--- a/Xcode Configurations/openWHO/openWHO-iOS-Debug.xcconfig
+++ b/Xcode Configurations/openWHO/openWHO-iOS-Debug.xcconfig
@@ -14,4 +14,4 @@ SWIFT_COMPILATION_MODE = singlefile
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 ENABLE_NS_ASSERTIONS = YES
 
-OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS" "-Xfrontend" "-warn-long-function-bodies=100" "-Xfrontend" "-warn-long-expression-type-checking=100"
+OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS" "-Xfrontend" "-warn-long-function-bodies=150" "-Xfrontend" "-warn-long-expression-type-checking=150"

--- a/Xcode Configurations/openWHO/openWHO-iOS-Debug.xcconfig
+++ b/Xcode Configurations/openWHO/openWHO-iOS-Debug.xcconfig
@@ -14,4 +14,4 @@ SWIFT_COMPILATION_MODE = singlefile
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 ENABLE_NS_ASSERTIONS = YES
 
-OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS"
+OTHER_SWIFT_FLAGS = $(inherited) -DDEBUG "-D" "COCOAPODS" "-Xfrontend" "-warn-long-function-bodies=100" "-Xfrontend" "-warn-long-expression-type-checking=100"


### PR DESCRIPTION
### Proposed Changes:
- Add compiler flag which create warnings if compile times for functions or expressions exceed the given threshold
- only in debug mode
- current threshold: 150ms


@bjrne please test this on your older machine. I don't want to set the threshold too low