### PR TITLE
Show time effort for course items

### DIFF
--- a/Common/Data/Model/CourseItem.swift
+++ b/Common/Data/Model/CourseItem.swift
@@ -13,6 +13,7 @@ public final class CourseItem: NSManagedObject {
     @NSManaged public var title: String?
     @NSManaged public var position: Int32
     @NSManaged public var visited: Bool
+    @NSManaged public var timeEffort: Int16
     @NSManaged public var maxPoints: Double
     @NSManaged public var proctored: Bool
     @NSManaged public var accessible: Bool
@@ -64,6 +65,7 @@ extension CourseItem: JSONAPIPullable {
         self.proctored = try attributes.value(for: "proctored")
         self.accessible = try attributes.value(for: "accessible")
         self.visited = try attributes.value(for: "visited") || self.visited  // course items can't be set to 'not visited'
+        self.timeEffort = (try? attributes.value(for: "time_effort")) ?? 0
 
         let relationships = try object.value(for: "relationships") as JSON
         try self.updateRelationship(forKeyPath: \Self.section,

--- a/Common/Data/xikolo.xcdatamodeld/xikolo 9.xcdatamodel/contents
+++ b/Common/Data/xikolo.xcdatamodeld/xikolo 9.xcdatamodel/contents
@@ -72,6 +72,7 @@
         <attribute name="objectStateValue" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="position" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO"/>
         <attribute name="proctored" optional="YES" attributeType="Boolean" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="timeEffort" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" optional="YES" attributeType="String"/>
         <attribute name="visited" optional="YES" attributeType="Boolean" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="content" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="Content" inverseName="item" inverseEntity="Content"/>
@@ -228,7 +229,7 @@
         <element name="Content" positionX="666" positionY="198" width="128" height="60"/>
         <element name="Course" positionX="45" positionY="-18" width="128" height="463"/>
         <element name="CourseDate" positionX="214" positionY="-180" width="128" height="120"/>
-        <element name="CourseItem" positionX="468" positionY="165" width="128" height="255"/>
+        <element name="CourseItem" positionX="468" positionY="165" width="128" height="268"/>
         <element name="CourseProgress" positionX="234" positionY="-63" width="128" height="133"/>
         <element name="CourseSection" positionX="286" positionY="306" width="128" height="180"/>
         <element name="Document" positionX="234" positionY="-63" width="128" height="150"/>

--- a/iOS/Data/Model/CourseItem+DetailedContent.swift
+++ b/iOS/Data/Model/CourseItem+DetailedContent.swift
@@ -7,10 +7,19 @@ import Common
 
 extension CourseItem {
 
-    var detailedContent: [DetailedData] {
-        var data = (self.content as? DetailedCourseItemContent)?.detailedContent ?? []
+    var detailedContent: [DetailedDataItem] {
+        var data: [DetailedDataItem] = []
+
+        if self.timeEffort > 0 {
+            data.append(DetailedDataItem.timeEffort(duration: TimeInterval(self.timeEffort)))
+        }
+
+        if let detailedContent = self.content as? DetailedCourseItemContent {
+            data += detailedContent.detailedData
+        }
+
         if self.maxPoints > 0.0 {
-            data.append(DetailedData.points(maxPoints: self.maxPoints))
+            data.append(DetailedDataItem.points(maxPoints: self.maxPoints))
         }
 
         return data

--- a/iOS/Data/Model/RichText+Preloading.swift
+++ b/iOS/Data/Model/RichText+Preloading.swift
@@ -11,14 +11,4 @@ extension RichText: PreloadableCourseItemContent {
         return "rich_text"
     }
 
-    var detailedContent: [DetailedData] {
-        let words = self.text?.components(separatedBy: CharacterSet.whitespacesAndNewlines)
-        guard let wordcount = words?.count else {
-            return []
-        }
-
-        let approximatedReadingTime = ceil(Double(wordcount) / 200) * 60
-        return [.text(readingTime: approximatedReadingTime)]
-    }
-
 }

--- a/iOS/Data/Model/Video+Preloading.swift
+++ b/iOS/Data/Model/Video+Preloading.swift
@@ -11,16 +11,12 @@ extension Video: PreloadableCourseItemContent {
         return "video"
     }
 
-    var detailedContent: [DetailedData] {
-        var content: [DetailedData] = [
-            .stream(duration: TimeInterval(self.duration)),
-        ]
+}
 
-        if self.slidesURL != nil {
-            content.append(.slides)
-        }
+extension Video: DetailedCourseItemContent {
 
-        return content
+    var detailedData: [DetailedDataItem] {
+        return self.slidesURL != nil ? [.slides] : []
     }
 
 }

--- a/iOS/Protocols/CourseItemCellDelegate.swift
+++ b/iOS/Protocols/CourseItemCellDelegate.swift
@@ -5,8 +5,6 @@
 
 protocol CourseItemCellDelegate: AnyObject {
 
-    var inOfflineMode: Bool { get }
-
-    func isPreloading(for contentType: String?) -> Bool
+    var isInOfflineMode: Bool { get }
 
 }

--- a/iOS/Protocols/DetailedCourseItemContent.swift
+++ b/iOS/Protocols/DetailedCourseItemContent.swift
@@ -7,14 +7,13 @@ import Foundation
 
 protocol DetailedCourseItemContent {
 
-    var detailedContent: [DetailedData] { get }
+    var detailedData: [DetailedDataItem] { get }
 
 }
 
-enum DetailedData {
+enum DetailedDataItem {
 
-    case text(readingTime: TimeInterval)
-    case stream(duration: TimeInterval)
+    case timeEffort(duration: TimeInterval)
     case slides
     case points(maxPoints: Double)
 

--- a/iOS/Protocols/PreloadableCourseItemContent.swift
+++ b/iOS/Protocols/PreloadableCourseItemContent.swift
@@ -7,7 +7,7 @@ import BrightFutures
 import Common
 import SyncEngine
 
-protocol PreloadableCourseItemContent: DetailedCourseItemContent {
+protocol PreloadableCourseItemContent {
 
     static var contentType: String { get }
 

--- a/iOS/Storyboards/Base.lproj/CourseLearnings.storyboard
+++ b/iOS/Storyboards/Base.lproj/CourseLearnings.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="CUD-8G-le9">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="CUD-8G-le9">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -60,32 +61,37 @@
                                                 <constraint firstAttribute="width" constant="8" id="bCL-MM-IsZ"/>
                                             </constraints>
                                         </view>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L8U-Fp-wH1">
-                                            <rect key="frame" x="24" y="37.5" width="28" height="28"/>
-                                            <constraints>
-                                                <constraint firstAttribute="height" constant="28" id="SKE-Ma-GnJ"/>
-                                                <constraint firstAttribute="width" constant="28" id="mLi-L0-3YS"/>
-                                            </constraints>
-                                        </imageView>
-                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="U0c-TZ-Kbb">
-                                            <rect key="frame" x="60" y="15.5" width="290" height="72.5"/>
+                                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="a1t-cU-PcV">
+                                            <rect key="frame" x="24" y="15" width="342" height="73"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="850" verticalCompressionResistancePriority="1000" text="Item Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vm4-Hr-k3d">
-                                                    <rect key="frame" x="0.0" y="0.0" width="290" height="20.5"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <nil key="highlightedColor"/>
-                                                    <attributedString key="userComments">
-                                                        <fragment content="#bc-ignore!">
-                                                            <attributes>
-                                                                <font key="NSFont" size="11" name="HelveticaNeue"/>
-                                                                <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
-                                                            </attributes>
-                                                        </fragment>
-                                                    </attributedString>
-                                                </label>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G72-sV-YTv" customClass="CourseItemDetailView" customModule="iOS" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="22.5" width="290" height="50"/>
-                                                </view>
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L8U-Fp-wH1">
+                                                    <rect key="frame" x="0.0" y="22.5" width="28" height="28"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="28" id="SKE-Ma-GnJ"/>
+                                                        <constraint firstAttribute="width" constant="28" id="mLi-L0-3YS"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" alignment="top" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="U0c-TZ-Kbb">
+                                                    <rect key="frame" x="36" y="0.5" width="306" height="72.5"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="850" verticalCompressionResistancePriority="1000" text="Item Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vm4-Hr-k3d">
+                                                            <rect key="frame" x="0.0" y="0.0" width="71.5" height="20.5"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                            <nil key="highlightedColor"/>
+                                                            <attributedString key="userComments">
+                                                                <fragment content="#bc-ignore!">
+                                                                    <attributes>
+                                                                        <font key="NSFont" size="11" name="HelveticaNeue"/>
+                                                                        <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                                                    </attributes>
+                                                                </fragment>
+                                                            </attributedString>
+                                                        </label>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="Qwj-mh-6JE">
+                                                            <rect key="frame" x="0.0" y="22.5" width="290" height="50"/>
+                                                        </stackView>
+                                                    </subviews>
+                                                </stackView>
                                             </subviews>
                                         </stackView>
                                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fOH-l8-5Rz">
@@ -109,35 +115,21 @@
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="f0u-JP-r4C" firstAttribute="centerX" secondItem="ruK-fv-bts" secondAttribute="centerX" id="1Xn-eF-a0S"/>
-                                        <constraint firstItem="L8U-Fp-wH1" firstAttribute="leading" secondItem="f0u-JP-r4C" secondAttribute="trailing" constant="8" symbolic="YES" id="5ec-mr-UVn"/>
-                                        <constraint firstItem="L8U-Fp-wH1" firstAttribute="leading" secondItem="ruK-fv-bts" secondAttribute="trailing" id="8VV-ed-bPc"/>
+                                        <constraint firstItem="a1t-cU-PcV" firstAttribute="leading" secondItem="dUS-v4-gua" secondAttribute="leadingMargin" constant="4" id="3jK-c9-Uea"/>
                                         <constraint firstAttribute="trailingMargin" secondItem="fOH-l8-5Rz" secondAttribute="trailing" constant="-8" id="BUB-Zb-j1P"/>
-                                        <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="U0c-TZ-Kbb" secondAttribute="bottom" constant="4" id="DIx-6W-Zzg"/>
+                                        <constraint firstItem="a1t-cU-PcV" firstAttribute="top" secondItem="dUS-v4-gua" secondAttribute="topMargin" constant="4" id="BWK-DY-Cc3"/>
                                         <constraint firstItem="f0u-JP-r4C" firstAttribute="centerY" secondItem="dUS-v4-gua" secondAttribute="centerY" id="GRk-aQ-NAp"/>
                                         <constraint firstItem="fOH-l8-5Rz" firstAttribute="top" secondItem="dUS-v4-gua" secondAttribute="top" id="HNg-3I-Bub"/>
-                                        <constraint firstItem="U0c-TZ-Kbb" firstAttribute="centerY" secondItem="dUS-v4-gua" secondAttribute="centerY" id="Haq-QN-4Hq"/>
                                         <constraint firstItem="ruK-fv-bts" firstAttribute="top" secondItem="dUS-v4-gua" secondAttribute="top" id="Iwo-lX-quA"/>
+                                        <constraint firstItem="a1t-cU-PcV" firstAttribute="trailing" secondItem="fOH-l8-5Rz" secondAttribute="leading" constant="8" symbolic="YES" id="Oip-Zb-4nO"/>
                                         <constraint firstItem="ruK-fv-bts" firstAttribute="leading" secondItem="dUS-v4-gua" secondAttribute="leading" id="Snc-YG-TmY"/>
-                                        <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="L8U-Fp-wH1" secondAttribute="bottom" constant="4" id="TOb-LX-QUc"/>
                                         <constraint firstAttribute="bottom" secondItem="ruK-fv-bts" secondAttribute="bottom" id="VmW-UF-Ag0"/>
-                                        <constraint firstItem="U0c-TZ-Kbb" firstAttribute="leading" secondItem="L8U-Fp-wH1" secondAttribute="trailing" constant="8" symbolic="YES" id="euH-Bi-ikq"/>
-                                        <constraint firstItem="fOH-l8-5Rz" firstAttribute="leading" secondItem="U0c-TZ-Kbb" secondAttribute="trailing" constant="8" symbolic="YES" id="gby-Ji-8uI"/>
-                                        <constraint firstItem="L8U-Fp-wH1" firstAttribute="leading" secondItem="dUS-v4-gua" secondAttribute="leadingMargin" constant="4" id="k49-og-pHl">
-                                            <variation key="widthClass=regular" constant="0.0"/>
-                                        </constraint>
-                                        <constraint firstItem="U0c-TZ-Kbb" firstAttribute="top" relation="greaterThanOrEqual" secondItem="dUS-v4-gua" secondAttribute="topMargin" constant="4" id="kXF-hn-UVQ"/>
-                                        <constraint firstItem="L8U-Fp-wH1" firstAttribute="centerY" secondItem="dUS-v4-gua" secondAttribute="centerY" id="kqj-Ta-P6o"/>
+                                        <constraint firstItem="a1t-cU-PcV" firstAttribute="leading" secondItem="ruK-fv-bts" secondAttribute="trailing" id="l9n-Z9-4M7"/>
                                         <constraint firstAttribute="bottom" secondItem="fOH-l8-5Rz" secondAttribute="bottom" id="lP4-cV-l3s"/>
-                                        <constraint firstItem="L8U-Fp-wH1" firstAttribute="top" relation="greaterThanOrEqual" secondItem="dUS-v4-gua" secondAttribute="topMargin" constant="4" id="o5j-3a-xZh"/>
+                                        <constraint firstAttribute="bottomMargin" secondItem="a1t-cU-PcV" secondAttribute="bottom" constant="4" id="sxK-U3-ers"/>
                                     </constraints>
-                                    <variation key="default">
-                                        <mask key="constraints">
-                                            <exclude reference="5ec-mr-UVn"/>
-                                        </mask>
-                                    </variation>
                                     <variation key="widthClass=regular">
                                         <mask key="constraints">
-                                            <include reference="5ec-mr-UVn"/>
                                             <exclude reference="1Xn-eF-a0S"/>
                                         </mask>
                                     </variation>
@@ -145,7 +137,7 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                 <connections>
                                     <outlet property="actionsButton" destination="fOH-l8-5Rz" id="yNy-Ag-Y7s"/>
-                                    <outlet property="detailContentView" destination="G72-sV-YTv" id="zyP-CW-sQY"/>
+                                    <outlet property="detailStackView" destination="Qwj-mh-6JE" id="5ZO-Y4-RfZ"/>
                                     <outlet property="iconView" destination="L8U-Fp-wH1" id="ZYN-fe-P6P"/>
                                     <outlet property="readStateView" destination="f0u-JP-r4C" id="Dda-eM-RsX"/>
                                     <outlet property="titleView" destination="vm4-Hr-k3d" id="OqI-3b-6NJ"/>

--- a/iOS/Storyboards/Base.lproj/CourseLearnings.storyboard
+++ b/iOS/Storyboards/Base.lproj/CourseLearnings.storyboard
@@ -116,6 +116,7 @@
                                     <constraints>
                                         <constraint firstItem="f0u-JP-r4C" firstAttribute="centerX" secondItem="ruK-fv-bts" secondAttribute="centerX" id="1Xn-eF-a0S"/>
                                         <constraint firstItem="a1t-cU-PcV" firstAttribute="leading" secondItem="dUS-v4-gua" secondAttribute="leadingMargin" constant="4" id="3jK-c9-Uea"/>
+                                        <constraint firstItem="a1t-cU-PcV" firstAttribute="leading" secondItem="f0u-JP-r4C" secondAttribute="trailing" constant="8" symbolic="YES" id="5ZI-YW-Tws"/>
                                         <constraint firstAttribute="trailingMargin" secondItem="fOH-l8-5Rz" secondAttribute="trailing" constant="-8" id="BUB-Zb-j1P"/>
                                         <constraint firstItem="a1t-cU-PcV" firstAttribute="top" secondItem="dUS-v4-gua" secondAttribute="topMargin" constant="4" id="BWK-DY-Cc3"/>
                                         <constraint firstItem="f0u-JP-r4C" firstAttribute="centerY" secondItem="dUS-v4-gua" secondAttribute="centerY" id="GRk-aQ-NAp"/>
@@ -128,8 +129,14 @@
                                         <constraint firstAttribute="bottom" secondItem="fOH-l8-5Rz" secondAttribute="bottom" id="lP4-cV-l3s"/>
                                         <constraint firstAttribute="bottomMargin" secondItem="a1t-cU-PcV" secondAttribute="bottom" constant="4" id="sxK-U3-ers"/>
                                     </constraints>
+                                    <variation key="default">
+                                        <mask key="constraints">
+                                            <exclude reference="5ZI-YW-Tws"/>
+                                        </mask>
+                                    </variation>
                                     <variation key="widthClass=regular">
                                         <mask key="constraints">
+                                            <include reference="5ZI-YW-Tws"/>
                                             <exclude reference="1Xn-eF-a0S"/>
                                         </mask>
                                     </variation>

--- a/iOS/ViewControllers/Courses/CourseItemListViewController.swift
+++ b/iOS/ViewControllers/Courses/CourseItemListViewController.swift
@@ -22,7 +22,6 @@ class CourseItemListViewController: UITableViewController {
 
     weak var scrollDelegate: CourseAreaScrollDelegate?
 
-    var isPreloading = false
     var inOfflineMode = !ReachabilityHelper.hasConnection {
         didSet {
             if oldValue != self.inOfflineMode {
@@ -74,10 +73,8 @@ class CourseItemListViewController: UITableViewController {
     }
 
     func preloadCourseContent() {
-        Self.contentToBePreloaded.traverse { contentType in
+        _ = Self.contentToBePreloaded.traverse { contentType in
             return contentType.preloadContent(forCourse: self.course)
-        }.onComplete { _ in
-            self.isPreloading = false
         }
     }
 
@@ -192,7 +189,6 @@ extension CourseItemListViewController: RefreshableViewController {
     }
 
     func refreshingAction() -> Future<Void, XikoloError> {
-        self.isPreloading = self.preloadingWanted && !Self.contentToBePreloaded.isEmpty
         return CourseSectionHelper.syncCourseSections(forCourse: self.course).flatMap { _ in
             return CourseItemHelper.syncCourseItems(forCourse: self.course)
         }.asVoid()
@@ -226,9 +222,7 @@ extension CourseItemListViewController: EmptyStateDataSource, EmptyStateDelegate
 
 extension CourseItemListViewController: CourseItemCellDelegate {
 
-    func isPreloading(for contentType: String?) -> Bool {
-        return self.isPreloading && Self.contentToBePreloaded.contains { $0.contentType == contentType }
-    }
+    var isInOfflineMode: Bool { self.inOfflineMode }
 
 }
 

--- a/iOS/Views/DetailedDataItemView.swift
+++ b/iOS/Views/DetailedDataItemView.swift
@@ -6,124 +6,6 @@
 import Common
 import UIKit
 
-//class CourseItemDetailView: UIView {
-//
-//    private let stackView: UIStackView = {
-//        let stackView = UIStackView()
-//        stackView.axis = .horizontal
-//        stackView.distribution = .fill
-//        stackView.alignment = .center
-//        stackView.spacing = 10.0
-//        stackView.translatesAutoresizingMaskIntoConstraints = false
-//        return stackView
-//    }()
-//
-//    private let shimmerView: UIView = {
-//        let view = UIView()
-//        view.backgroundColor = ColorCompatibility.systemFill
-//        view.layer.cornerRadius = view.frame.height / 2
-//        view.layer.masksToBounds = true
-//        view.translatesAutoresizingMaskIntoConstraints = false
-//        view.isHidden = true
-//        return view
-//    }()
-//
-//    var isShimmering: Bool = false {
-//        didSet {
-//            guard self.isShimmering != oldValue else { return }
-//
-//            self.stackView.isHidden = self.isShimmering
-//            self.shimmerView.isHidden = !self.isShimmering
-//
-//            let animationKey = "shimmer"
-//            if self.isShimmering, self.shimmerView.layer.animation(forKey: animationKey) == nil {
-//                self.shimmerView.layer.add(self.pulseAnimation, forKey: animationKey)
-//            } else {
-//                self.shimmerView.layer.removeAnimation(forKey: animationKey)
-//            }
-//        }
-//    }
-//
-//    private var courseItem: CourseItem?
-//
-//    override func awakeFromNib() {
-//        super.awakeFromNib()
-//
-//        self.addSubview(self.stackView)
-//        self.addSubview(self.shimmerView)
-//
-//        NSLayoutConstraint.activate([
-//            self.stackView.topAnchor.constraint(equalTo: self.topAnchor),
-//            self.stackView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-//            self.stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-//            self.stackView.trailingAnchor.constraint(lessThanOrEqualTo: self.trailingAnchor),
-//            self.shimmerView.topAnchor.constraint(equalTo: self.topAnchor, constant: 3),
-//            self.shimmerView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 3),
-//            self.shimmerView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-//            self.shimmerView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.5),
-//        ])
-//    }
-//
-//    override func layoutSubviews() {
-//        super.layoutSubviews()
-//        self.shimmerView.layer.cornerRadius = self.shimmerView.frame.height / 2
-//    }
-//
-//    override var intrinsicContentSize: CGSize {
-//        let superSize = super.intrinsicContentSize
-//        let height = max(superSize.height, UIFont.preferredFont(forTextStyle: .caption1).lineHeight)
-//        return CGSize(width: superSize.width, height: height)
-//    }
-//
-//    func configure(for courseItem: CourseItem, with delegate: CourseItemCellDelegate?) {
-//        self.courseItem = courseItem
-//
-//        let detailedContent = courseItem.detailedContent
-//        if !detailedContent.isEmpty {
-//            self.setContent(detailedContent, inOfflineMode: delegate?.inOfflineMode ?? false)
-//            self.isHidden = false
-////        } else if delegate?.isPreloading(for: courseItem.contentType) ?? false {
-////            self.isShimmering = true
-////            self.isHidden = false
-//        } else {
-//            self.isHidden = true
-//        }
-//    }
-//
-//    private func setContent(_ content: [DetailedData], inOfflineMode isOffline: Bool) {
-//        self.stackView.arrangedSubviews.forEach { view in
-//            self.stackView.removeArrangedSubview(view)
-//            view.removeFromSuperview()
-//        }
-//
-//        let video = self.courseItem?.content as? Video
-//
-//        for contentItem in content {
-//            let view = DetailedDataView()
-//            view.configure(for: contentItem, for: video, inOfflineMode: isOffline)
-//            self.stackView.addArrangedSubview(view)
-//        }
-//
-//        self.isShimmering = false
-//    }
-//
-//    private var pulseAnimation: CAAnimation {
-//        let pulseAnimation = CABasicAnimation(keyPath: #keyPath(CALayer.backgroundColor))
-//
-//        self.traitCollection.performAsCurrent {
-//            pulseAnimation.fromValue = ColorCompatibility.systemFill.cgColor
-//            pulseAnimation.toValue = ColorCompatibility.secondarySystemFill.cgColor
-//        }
-//
-//        pulseAnimation.duration = 1
-//        pulseAnimation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-//        pulseAnimation.autoreverses = true
-//        pulseAnimation.repeatCount = .infinity
-//        return pulseAnimation
-//    }
-//
-//}
-
 class DetailedDataItemView: UIStackView {
 
     var videoId: String?
@@ -138,17 +20,6 @@ class DetailedDataItemView: UIStackView {
         formatter.allowedUnits = [.hour, .minute]
         return formatter
     }()
-
-//    private static let videoDurationFormatter: DateComponentsFormatter = {
-//        var calendar = Calendar.current
-//        calendar.locale = Locale.current
-//        let formatter = DateComponentsFormatter()
-//        formatter.calendar = calendar
-//        formatter.unitsStyle = .abbreviated
-//        formatter.allowedUnits = [.minute, .second]
-//        formatter.zeroFormattingBehavior = [.pad]
-//        return formatter
-//    }()
 
     private static let pointsFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
@@ -220,34 +91,26 @@ class DetailedDataItemView: UIStackView {
         self.spacing = 3.0
 
         let progressConfiguration: (state: DownloadState?, progress: Double?) = {
-            guard let video = video else { return (.notDownloaded, nil) } // Currently we only support course items with video to be downloaded
+            guard let video = video else { return (.notDownloaded, nil) } // Currently we only support video course items to be downloaded
 
             switch data {
             case .timeEffort:
                 return (StreamPersistenceManager.shared.downloadState(for: video), StreamPersistenceManager.shared.downloadProgress(for: video))
-//                return (.notDownloaded, nil)
-//            case .text(readingTime: _):
-//                return (.notDownloaded, nil)
-//            case .stream(duration: _):
-//                return (StreamPersistenceManager.shared.downloadState(for: video), StreamPersistenceManager.shared.downloadProgress(for: video))
             case .slides:
                 return (SlidesPersistenceManager.shared.downloadState(for: video), SlidesPersistenceManager.shared.downloadProgress(for: video))
-            case .points(maxPoints: _):
+            case .points:
                 return (.notDownloaded, nil)
             }
         }()
 
         let textLabel = self.textLabel(forContentItem: data, in: progressConfiguration.state, inOfflineMode: inOfflineMode)
         self.addArrangedSubview(textLabel)
-//        textLabel.setContentCompressionResistancePriority(.required, for: .vertical)
 
         if progressConfiguration.state == .pending || progressConfiguration.state == .downloading {
             self.addArrangedSubview(self.progressView)
             self.progressView.updateProgress(progressConfiguration.progress, animated: false)
-//            self.progressView.setContentCompressionResistancePriority(.required, for: .vertical)
         } else if progressConfiguration.state == .downloaded {
             self.addArrangedSubview(self.downloadedIcon)
-//            self.downloadedIcon.setContentCompressionResistancePriority(.required, for: .vertical)
         }
 
         NotificationCenter.default.addObserver(self,
@@ -267,16 +130,10 @@ class DetailedDataItemView: UIStackView {
             let value = ceil(duration / 60) * 60 // round up to full minutes
             label.text = Self.timeEffortFormatter.string(from: value)
             downloaded = downloadState == .downloaded
-//        case let .text(readingTime: readingTime):
-//            label.text = Self.readingTimeFormatter.string(from: readingTime)
-//            downloaded = true
-//        case let .stream(duration: duration):
-//            label.text = Self.videoDurationFormatter.string(from: duration)
-//            downloaded = downloadState == .downloaded
         case .slides:
             label.text = NSLocalizedString("course-item.video.slides.label", comment: "Shown in course content list")
             downloaded = downloadState == .downloaded
-        case let .points(maxPoints: maxPoints):
+        case let .points(maxPoints):
             let format = NSLocalizedString("course-item.max-points", comment: "maximum points for course item")
             let number = NSNumber(value: maxPoints)
             let formattedNumber = Self.pointsFormatter.string(from: number)
@@ -300,11 +157,5 @@ class DetailedDataItemView: UIStackView {
             self.progressView.updateProgress(progress)
         }
     }
-
-//    override func systemLayoutSizeFitting(_ targetSize: CGSize, withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority, verticalFittingPriority: UILayoutPriority) -> CGSize {
-//        let size = super.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: horizontalFittingPriority, verticalFittingPriority: verticalFittingPriority)
-//
-//        return size
-//    }
 
 }

--- a/xikolo-ios.xcodeproj/project.pbxproj
+++ b/xikolo-ios.xcodeproj/project.pbxproj
@@ -169,7 +169,7 @@
 		50CF1F5020DCDBFC0011BFE9 /* CourseDismissAnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5040A62B207978BA00E98351 /* CourseDismissAnimationController.swift */; };
 		50CF1F5120DCDBFC0011BFE9 /* PersistenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50082B4F20BFDA7800B4511C /* PersistenceManager.swift */; };
 		50CF1F5520DCDBFC0011BFE9 /* FilePersistenceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50082B5420BFDA8800B4511C /* FilePersistenceManager.swift */; };
-		50CF1F5820DCDBFC0011BFE9 /* CourseItemDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50371FFD20501388006E9634 /* CourseItemDetailView.swift */; };
+		50CF1F5820DCDBFC0011BFE9 /* DetailedDataItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50371FFD20501388006E9634 /* DetailedDataItemView.swift */; };
 		50CF1F5920DCDBFC0011BFE9 /* CourseSection+Download.swift in Sources */ = {isa = PBXBuildFile; fileRef = 500228F620583DF9003301A7 /* CourseSection+Download.swift */; };
 		50CF1F5B20DCDBFC0011BFE9 /* CouseContent+image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502F3DDC209C35ED006B3DAC /* CouseContent+image.swift */; };
 		50CF1F5C20DCDBFC0011BFE9 /* CourseDateListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2B821C1DDB0EE200559217 /* CourseDateListViewController.swift */; };
@@ -548,7 +548,7 @@
 		5036A9B42319232800F7A63F /* UIWindow+FullScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+FullScreen.swift"; sourceTree = "<group>"; };
 		5036E32E23292C830074117C /* ScreenshotsDark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotsDark.swift; sourceTree = "<group>"; };
 		50371FF8204ECB8E006E9634 /* CircularProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
-		50371FFD20501388006E9634 /* CourseItemDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseItemDetailView.swift; sourceTree = "<group>"; };
+		50371FFD20501388006E9634 /* DetailedDataItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailedDataItemView.swift; sourceTree = "<group>"; };
 		503988722166920400F9043B /* ShadowContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowContainerView.swift; sourceTree = "<group>"; };
 		5039887421679A0600F9043B /* CourseItemCellDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseItemCellDelegate.swift; sourceTree = "<group>"; };
 		5039887621679A3500F9043B /* PreloadableCourseItemContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreloadableCourseItemContent.swift; sourceTree = "<group>"; };
@@ -994,7 +994,7 @@
 				50146FCC2222879D00177E96 /* CourseSearchFilterCell.swift */,
 				500228EC20582573003301A7 /* CourseItemHeader.swift */,
 				AB91F9E41CED029B00007D06 /* CourseItemCell.swift */,
-				50371FFD20501388006E9634 /* CourseItemDetailView.swift */,
+				50371FFD20501388006E9634 /* DetailedDataItemView.swift */,
 				5017B3BD2049854F001D90A1 /* CourseAreaCell.swift */,
 				AB2802D31D2AC425008C8BAE /* AnnouncementCell.swift */,
 				4E2B80AA1DDDE43D0058552D /* CourseDateCell.swift */,
@@ -2302,7 +2302,7 @@
 				5011EF03212AEC3800B1D7F1 /* DocumentLocalizationCell.swift in Sources */,
 				50CF1F5120DCDBFC0011BFE9 /* PersistenceManager.swift in Sources */,
 				50CF1F5520DCDBFC0011BFE9 /* FilePersistenceManager.swift in Sources */,
-				50CF1F5820DCDBFC0011BFE9 /* CourseItemDetailView.swift in Sources */,
+				50CF1F5820DCDBFC0011BFE9 /* DetailedDataItemView.swift in Sources */,
 				50E0351F213673F8001F963D /* CourseListConfiguration.swift in Sources */,
 				50CF1F5920DCDBFC0011BFE9 /* CourseSection+Download.swift in Sources */,
 				50CF1F5B20DCDBFC0011BFE9 /* CouseContent+image.swift in Sources */,


### PR DESCRIPTION
Fixes #729

### Proposed Changes:
- Show effort provided by the server for all course items
- By extension, the following change hab to be performed:
  - Remove preloading UI (shimmer) for course items
  - Split course item protocols for preloading and detailed content
  - The `time effort` detailed data replaces `stream` and `text`
  - Adjust/Improv storyboard file for course item cell