### PR TITLE
Show relative course dates in course date overview and list

### DIFF
--- a/Common/Data/Model/CourseDate.swift
+++ b/Common/Data/Model/CourseDate.swift
@@ -8,6 +8,15 @@ import SyncEngine
 
 public final class CourseDate: NSManagedObject {
 
+    @available(iOS 13, *)
+    private static let relativeCourseDateTimeFormatter: RelativeDateTimeFormatter = {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.calendar = Calendar.autoupdatingCurrent
+        formatter.locale = Locale.autoupdatingCurrent
+        formatter.dateTimeStyle = .named
+        return formatter
+    }()
+
     @NSManaged public var id: String
     @NSManaged public var title: String?
     @NSManaged public var type: String?
@@ -18,19 +27,10 @@ public final class CourseDate: NSManagedObject {
         return NSFetchRequest<CourseDate>(entityName: "CourseDate")
     }
 
-    private static let dateFormatter = DateFormatter.localizedFormatter(dateStyle: .long, timeStyle: .short)
-
-    public var formattedDateWithTimeZone: String? {
-        guard let date = self.date else {
-            return nil
-        }
-
-        var dateText = Self.dateFormatter.string(from: date)
-        if let timeZoneAbbreviation = TimeZone.current.abbreviation() {
-            dateText += " (\(timeZoneAbbreviation))"
-        }
-
-        return dateText
+    @available(iOS 13, *)
+    @objc public var relativeDateTime: String? {
+        guard let date = self.date else { return nil }
+        return Self.relativeCourseDateTimeFormatter.localizedString(for: date, relativeTo: Date())
     }
 
     public var contextAwareTitle: String {

--- a/iOS/Storyboards/Base.lproj/CourseDateOverview.storyboard
+++ b/iOS/Storyboards/Base.lproj/CourseDateOverview.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hhS-q8-HuO">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hhS-q8-HuO">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -252,10 +252,25 @@
                                                     <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" ambiguous="YES" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="7KP-OG-l3b">
                                                         <rect key="frame" x="16" y="27" width="342" height="58"/>
                                                         <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" ambiguous="YES" text="relative date time" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1eM-l2-sjr">
+                                                                <rect key="frame" x="0.0" y="0.0" width="342" height="20.5"/>
+                                                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                                <nil key="highlightedColor"/>
+                                                                <attributedString key="userComments">
+                                                                    <fragment content="#bc-ignore!">
+                                                                        <attributes>
+                                                                            <font key="NSFont" size="11" name="HelveticaNeue"/>
+                                                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
+                                                                        </attributes>
+                                                                    </fragment>
+                                                                </attributedString>
+                                                            </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" ambiguous="YES" text="date" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uwO-xj-R53">
-                                                                <rect key="frame" x="0.0" y="0.0" width="342" height="14.5"/>
+                                                                <rect key="frame" x="0.0" y="28.5" width="342" height="13.5"/>
                                                                 <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                                <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                                 <attributedString key="userComments">
                                                                     <fragment content="#bc-ignore!">
@@ -267,7 +282,7 @@
                                                                 </attributedString>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" ambiguous="YES" text="course" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xGq-3u-qqc">
-                                                                <rect key="frame" x="0.0" y="22.5" width="342" height="13.5"/>
+                                                                <rect key="frame" x="0.0" y="50" width="342" height="0.0"/>
                                                                 <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                                 <nil key="highlightedColor"/>
@@ -281,7 +296,7 @@
                                                                 </attributedString>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" ambiguous="YES" text="title" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qFX-kT-5GC">
-                                                                <rect key="frame" x="0.0" y="44" width="342" height="14"/>
+                                                                <rect key="frame" x="0.0" y="58" width="342" height="0.0"/>
                                                                 <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                 <nil key="highlightedColor"/>
@@ -342,6 +357,7 @@
                         <outlet property="nextUpContainer" destination="lRM-3x-ACb" id="HdN-20-a6D"/>
                         <outlet property="nextUpView" destination="E0S-23-0P0" id="m6t-ZT-oI1"/>
                         <outlet property="nextUpWidthConstraint" destination="xc5-gT-LjO" id="F5o-aC-kU5"/>
+                        <outlet property="relativeDateTimeLabel" destination="1eM-l2-sjr" id="S0Q-k4-18Y"/>
                         <outlet property="summaryContainer" destination="N41-ef-baw" id="xWI-NO-5ab"/>
                         <outlet property="summaryWidthConstraint" destination="X1A-b6-Lv8" id="4tN-4P-8hI"/>
                         <outlet property="titleLabel" destination="qFX-kT-5GC" id="KIO-9T-5MQ"/>

--- a/iOS/Storyboards/Base.lproj/CourseDates.storyboard
+++ b/iOS/Storyboards/Base.lproj/CourseDates.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="TzN-ab-aeu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="TzN-ab-aeu">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,25 +11,25 @@
         <scene sceneID="cpo-J6-K8J">
             <objects>
                 <tableViewController id="TzN-ab-aeu" customClass="CourseDateListViewController" customModule="iOS" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="uSi-6e-ygS">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="uSi-6e-ygS">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="CourseDateCell" id="rl9-bq-Z74" customClass="CourseDateCell" customModule="iOS" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="414" height="79"/>
+                                <rect key="frame" x="20" y="55.5" width="374" height="79"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" tableViewCell="rl9-bq-Z74" id="we2-zY-m1M">
-                                    <rect key="frame" x="0.0" y="0.0" width="383" height="79"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="343" height="79"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Ym6-4L-lMw">
-                                            <rect key="frame" x="20" y="11" width="355" height="57"/>
+                                            <rect key="frame" x="20" y="11" width="315" height="57"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="800" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BaE-wZ-2o2">
-                                                    <rect key="frame" x="0.0" y="0.0" width="355" height="15"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="315" height="15"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                     <attributedString key="userComments">
                                                         <fragment content="#bc-ignore!">
@@ -41,7 +41,7 @@
                                                     </attributedString>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="999" verticalCompressionResistancePriority="1000" text="Course" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="grh-cI-he0">
-                                                    <rect key="frame" x="0.0" y="19" width="355" height="13.5"/>
+                                                    <rect key="frame" x="0.0" y="19" width="315" height="13.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -55,7 +55,7 @@
                                                     </attributedString>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zOC-D7-bV6">
-                                                    <rect key="frame" x="0.0" y="36.5" width="355" height="20.5"/>
+                                                    <rect key="frame" x="0.0" y="36.5" width="315" height="20.5"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -78,6 +78,7 @@
                                         <constraint firstItem="Ym6-4L-lMw" firstAttribute="top" secondItem="we2-zY-m1M" secondAttribute="topMargin" id="oKV-8m-FGL"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <color key="backgroundColor" systemColor="secondarySystemBackgroundColor" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <connections>
                                     <outlet property="courseLabel" destination="grh-cI-he0" id="GoZ-2g-9WT"/>
                                     <outlet property="dateLabel" destination="BaE-wZ-2o2" id="hgY-p6-uOk"/>

--- a/iOS/ViewControllers/CoreDataTableViewDataSource.swift
+++ b/iOS/ViewControllers/CoreDataTableViewDataSource.swift
@@ -67,6 +67,10 @@ class CoreDataTableViewDataSource<Delegate: CoreDataTableViewDataSourceDelegate>
         self.tableView?.reloadData()
     }
 
+    var sectionInfos: [NSFetchedResultsSectionInfo]? {
+        return self.fetchedResultsController.sections
+    }
+
     func object(at indexPath: IndexPath) -> Object {
         return self.fetchedResultsController.object(at: indexPath)
     }

--- a/iOS/ViewControllers/Dashboard/CourseDateListViewController.swift
+++ b/iOS/ViewControllers/Dashboard/CourseDateListViewController.swift
@@ -18,14 +18,39 @@ class CourseDateListViewController: UITableViewController {
         self.addRefreshControl()
 
         // setup table view data
+        let sectionNameKeyPath: String? = {
+            if #available(iOS 13, *) {
+                return "relativeDateTime"
+            } else {
+                return nil
+            }
+        }()
+
         let reuseIdentifier = R.reuseIdentifier.courseDateCell.identifier
-        let resultsController = CoreDataHelper.createResultsController(CourseDateHelper.FetchRequest.allCourseDates, sectionNameKeyPath: nil)
+        let resultsController = CoreDataHelper.createResultsController(CourseDateHelper.FetchRequest.allCourseDates, sectionNameKeyPath: sectionNameKeyPath)
         self.dataSource = CoreDataTableViewDataSource(self.tableView,
                                                       fetchedResultsController: resultsController,
                                                       cellReuseIdentifier: reuseIdentifier,
                                                       delegate: self)
 
         self.setupEmptyState()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        if #available(iOS 13, *) {
+            // workaround to correct show table view section header on load
+            if animated {
+                self.tableView.beginUpdates()
+                self.tableView.endUpdates()
+            } else {
+                UIView.performWithoutAnimation {
+                    self.tableView.beginUpdates()
+                    self.tableView.endUpdates()
+                }
+            }
+        }
     }
 
 }
@@ -49,6 +74,14 @@ extension CourseDateListViewController: CoreDataTableViewDataSourceDelegate {
 
     func configure(_ cell: CourseDateCell, for object: CourseDate) {
         cell.configure(for: object)
+
+        if #available(iOS 13, *) {} else {
+            cell.backgroundColor = ColorCompatibility.systemBackground
+        }
+    }
+
+    func titleForDefaultHeader(forSection section: Int) -> String? {
+        return self.dataSource?.sectionInfos?[section].name
     }
 
 }

--- a/iOS/ViewControllers/Dashboard/CourseDateOverviewViewController.swift
+++ b/iOS/ViewControllers/Dashboard/CourseDateOverviewViewController.swift
@@ -18,10 +18,17 @@ class CourseDateOverviewViewController: UIViewController {
 
     @IBOutlet private weak var nextUpView: UIView!
     @IBOutlet private weak var nextUpContainer: UIView!
+    @IBOutlet private weak var relativeDateTimeLabel: UILabel!
     @IBOutlet private weak var dateLabel: UILabel!
     @IBOutlet private weak var courseLabel: UILabel!
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private var nextUpWidthConstraint: NSLayoutConstraint!
+
+    private lazy var courseDateFormatter: DateFormatter = {
+        let formatter = DateFormatter.localizedFormatter(dateStyle: .long, timeStyle: .long)
+        formatter.doesRelativeDateFormatting = true
+        return formatter
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -63,10 +70,16 @@ class CourseDateOverviewViewController: UIViewController {
         self.allCountLabel.text = self.formattedItemCount(for: CourseDateHelper.FetchRequest.allCourseDates)
 
         if let courseDate = CoreDataHelper.viewContext.fetchSingle(CourseDateHelper.FetchRequest.nextCourseDate).value {
-            self.dateLabel.text = courseDate.formattedDateWithTimeZone
+            self.dateLabel.text = courseDate.date.map(self.courseDateFormatter.string(from:))
             self.courseLabel.text = courseDate.course?.title
             self.titleLabel.text = courseDate.contextAwareTitle
             self.nextUpView.isHidden = false
+
+            if #available(iOS 13, *) {
+                self.relativeDateTimeLabel.text = courseDate.relativeDateTime?.uppercased(with: Locale.current)
+            } else {
+                self.relativeDateTimeLabel.text = nil
+            }
         } else {
             self.nextUpView.isHidden = true
         }

--- a/iOS/Views/CourseDateCell.swift
+++ b/iOS/Views/CourseDateCell.swift
@@ -9,6 +9,8 @@ import UIKit
 
 class CourseDateCell: UITableViewCell {
 
+    private static let courseDateFormatter = DateFormatter.localizedFormatter(dateStyle: .long, timeStyle: .long)
+
     @IBOutlet private var courseLabel: UILabel!
     @IBOutlet private var titleLabel: UILabel!
     @IBOutlet private var dateLabel: UILabel!
@@ -19,7 +21,7 @@ class CourseDateCell: UITableViewCell {
     }
 
     func configure(for courseDate: CourseDate) {
-        self.dateLabel.text = courseDate.formattedDateWithTimeZone
+        self.dateLabel.text = courseDate.date.map(Self.courseDateFormatter.string(from:))
         self.courseLabel.text = courseDate.course?.title
         self.titleLabel.text = courseDate.contextAwareTitle
     }


### PR DESCRIPTION
Fixes #745

### Proposed Changes:
- iOS 13 only, as `RelativeDateTimeFormatter` is available starting with iOS 13
- show remaining (relative) time up to next deadline in "next up" view on the dashboard (additionally to absolute date)
- Group course date list by relative time