### PR TITLE
resume background audio when video stops playing

### DIFF
--- a/iOS/ViewControllers/Courses/CourseDetailsViewController.swift
+++ b/iOS/ViewControllers/Courses/CourseDetailsViewController.swift
@@ -170,7 +170,7 @@ class CourseDetailsViewController: UIViewController {
 
         self.present(playerViewController, animated: trueUnlessReduceMotionEnabled) {
             playerViewController.startPlayback()
-            try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+            try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
         }
     }
 

--- a/iOS/ViewControllers/Courses/CourseListViewController.swift
+++ b/iOS/ViewControllers/Courses/CourseListViewController.swift
@@ -253,7 +253,7 @@ extension CourseListViewController: ChannelHeaderViewDelegate {
         playerViewController.asset = AVURLAsset(url: url)
         self.present(playerViewController, animated: trueUnlessReduceMotionEnabled) {
             playerViewController.startPlayback()
-            try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+            try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
         }
     }
 

--- a/iOS/ViewControllers/Courses/VideoViewController.swift
+++ b/iOS/ViewControllers/Courses/VideoViewController.swift
@@ -252,7 +252,7 @@ class VideoViewController: UIViewController {
         video.managedObjectContext?.refresh(video, mergeChanges: true)
 
         self.playerViewController?.configure(for: video)
-        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
     }
 
     @IBAction private func openSlides() {


### PR DESCRIPTION
Fixes #698 

Previously, when users played music in the background while using the app, the music stopped as soon as a video was started but didn't resume, when the video was stopped again. 
Now, I adjusted the AVAudioSession mode so the music played in the background will resume once the video is stopped.

### Proposed Changes:
