### PR TITLE
Add fastlane command to export localization strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ fastlane/test_output
 # Appfile with sensitive values
 fastlane/Appfile
 
+# Localization exports
+fastlane/localization-export
+
 # UI Tests
 iOS-UITests/Credentials.plist
 iOS-UITests/Credentials-*.plist

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,6 @@ gem 'fastlane', '~> 2.55'
 # https://github.com/danger/danger/issues/1055
 # https://github.com/ruby-git/ruby-git/pull/405
 gem 'git', :git => 'https://github.com/ruby-git/ruby-git.git', :tag => 'v1.6.0.pre1'
+
+# For XML/XLIFF parsing
+gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
+    mini_portile2 (2.4.0)
     minitest (5.14.0)
     molinillo (0.6.6)
     multi_json (1.14.1)
@@ -220,6 +221,8 @@ GEM
     naturally (2.2.0)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -289,6 +292,7 @@ DEPENDENCIES
   danger-swiftlint (~> 0.11)
   fastlane (~> 2.55)
   git!
+  nokogiri
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -319,4 +319,48 @@ platform :ios do
       UI.success "Feel you to make further changes."
     end
   end
+
+  desc "Export localizations and strip unwanted strings"
+  lane :export_localizations do
+
+    require 'nokogiri'
+
+    project = '../xikolo-ios.xcodeproj'
+    localization_path = 'localization-export'
+    xliff_location = "#{localization_path}/en.xcloc/Localized Contents/en.xliff"
+
+    sh("xcodebuild -exportLocalizations -project #{project} -localizationPath #{localization_path}")
+
+    # remove unwanted translation units
+    file = File.read(xliff_location)
+    xml = Nokogiri::XML(file)
+
+    exclude_indicators = [
+      '#bc-ignore!',
+      'No comment provided by engineer',
+      'Bundle name',
+    ]
+
+    xml.search("trans-unit").each do |node|
+      note = node.search("note").inner_text
+      should_exclude = exclude_indicators.any? { |indicator| note.include?(indicator) }
+      node.remove if should_exclude
+    end
+
+    File.open(xliff_location, "w") do |f|
+      f.write xml.to_xml
+    end
+
+    # remove files without translation units
+    file = File.read(xliff_location)
+    xml = Nokogiri::XML(file)
+
+    xml.search("file").each do |node|
+      node.remove if node.search("body").children.length < 2
+    end
+
+    File.open(xliff_location, "w") do |f|
+      f.write xml.to_xml
+    end
+  end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -260,6 +260,11 @@ fastlane ios changelog
 fastlane ios check_core_data
 ```
 Check if the core data model was modified since the last release
+### ios export_localizations
+```
+fastlane ios export_localizations
+```
+Export localizations and strip unwanted strings
 
 ----
 


### PR DESCRIPTION
* Remove strings that are excluded by BartyCrouch via `#bc0ignore!`
* Remove files without localization strings