### PR TITLE
Refresh data when unenrolling from courses 

### DIFF
--- a/Common/Data/RelationshipKeyPath.swift
+++ b/Common/Data/RelationshipKeyPath.swift
@@ -1,0 +1,59 @@
+//
+//  Created for xikolo-ios under MIT license.
+//  Copyright © HPI. All rights reserved.
+//
+
+import CoreData
+
+/// Describes a relationship key path for a Core Data entity.
+public struct RelationshipKeyPath: Hashable {
+
+    /// The destination property name we're observing
+    let destinationPropertyName: String
+
+    let destinationEntityName: String
+
+    let relationshipKeyPaths: [String]
+
+    /// The inverse property names of this relationship. Can be used to get the affected object IDs.
+    let inverseRelationshipKeyPaths: [String]
+
+    public init(keyPath: String, relationships: [String: NSRelationshipDescription]?) {
+        let splittedKeyPath = keyPath.split(separator: ".").map(String.init)
+
+        var destinationEntity: NSEntityDescription?
+        var relationships2: [NSRelationshipDescription?] = []
+        var inverseRelationship: [NSRelationshipDescription?] = []
+        var destinationProperty: NSPropertyDescription?
+
+        var relationshipsByName: [String: NSRelationshipDescription]? = relationships
+        var propertiesByName: [String: NSPropertyDescription]? = [:]
+        for relationshipName in splittedKeyPath {
+            if let relationship = relationshipsByName?[relationshipName] {
+                destinationEntity = relationship.destinationEntity
+                relationships2.append(relationship)
+                inverseRelationship.append(relationship.inverseRelationship)
+                relationshipsByName = relationship.destinationEntity?.relationshipsByName
+                propertiesByName = relationship.destinationEntity?.propertiesByName
+            } else if let property = propertiesByName?[relationshipName] {
+                destinationProperty = property
+            } else {
+                assertionFailure("Invalid key path is used")
+            }
+        }
+
+        self.destinationEntityName = destinationEntity?.name ?? ""
+        self.destinationPropertyName = destinationProperty?.name ?? ""
+        self.relationshipKeyPaths = relationships2.map { $0?.name ?? "" }
+        self.inverseRelationshipKeyPaths = inverseRelationship.map { $0?.name ?? "" }
+
+        assert(!self.destinationEntityName.isEmpty, "Invalid key path is used")
+        self.relationshipKeyPaths.forEach { property in
+            assert(!property.isEmpty, "Invalid key path is used")
+        }
+        self.inverseRelationshipKeyPaths.forEach { property in
+            assert(!property.isEmpty, "Invalid key path is used")
+        }
+    }
+
+}

--- a/Common/Data/RelationshipKeyPathsObserver.swift
+++ b/Common/Data/RelationshipKeyPathsObserver.swift
@@ -5,74 +5,6 @@
 
 import CoreData
 
-/// Describes a relationship key path for a Core Data entity.
-public struct RelationshipKeyPath: Hashable {
-
-    /// The destination property name we're observing
-    let destinationPropertyName: String
-
-    let destinationEntityName: String
-
-    let relationshipKeyPaths: [String]
-
-    /// The inverse property names of this relationship. Can be used to get the affected object IDs.
-    let inverseRelationshipKeyPaths: [String]
-
-    public init(keyPath: String, relationships: [String: NSRelationshipDescription]?) {
-        let splittedKeyPath = keyPath.split(separator: ".").map(String.init)
-
-        var destinationEntity: NSEntityDescription?
-        var relationships2: [NSRelationshipDescription?] = []
-        var inverseRelationship: [NSRelationshipDescription?] = []
-        var destinationProperty: NSPropertyDescription?
-
-        var relationshipsByName: [String: NSRelationshipDescription]? = relationships
-        var propertiesByName: [String: NSPropertyDescription]? = [:]
-        for relationshipName in splittedKeyPath {
-            if let relationship = relationshipsByName?[relationshipName] {
-                destinationEntity = relationship.destinationEntity
-                relationships2.append(relationship)
-                inverseRelationship.append(relationship.inverseRelationship)
-                relationshipsByName = relationship.destinationEntity?.relationshipsByName
-                propertiesByName = relationship.destinationEntity?.propertiesByName
-            } else if let property = propertiesByName?[relationshipName] {
-                destinationProperty = property
-            } else {
-                assertionFailure("Invalid key path is used")
-            }
-        }
-
-        self.destinationEntityName = destinationEntity?.name ?? ""
-        self.destinationPropertyName = destinationProperty?.name ?? ""
-        self.relationshipKeyPaths = relationships2.map { $0?.name ?? "" }
-        self.inverseRelationshipKeyPaths = inverseRelationship.map { $0?.name ?? "" }
-
-        assert(!self.destinationEntityName.isEmpty, "Invalid key path is used")
-        self.relationshipKeyPaths.forEach { property in
-            assert(!property.isEmpty, "Invalid key path is used")
-        }
-        self.inverseRelationshipKeyPaths.forEach { property in
-            assert(!property.isEmpty, "Invalid key path is used")
-        }
-    }
-
-}
-
-private extension NSManagedObject {
-
-    /// Matches the given key paths to the current changes of this `NSManagedObject`.
-    /// - Parameter keyPaths: The key paths to match the changes for.
-    /// - Returns: The matching relationship key path if found. Otherwise, `nil`.
-    func changedKeyPath(from keyPaths: Set<RelationshipKeyPath>, refreshed: Bool) -> RelationshipKeyPath? {
-        return keyPaths.first { keyPath -> Bool in
-            guard keyPath.destinationEntityName == entity.name || keyPath.destinationEntityName == entity.superentity?.name else { return false }
-            return refreshed || changedValues().keys.contains(keyPath.destinationPropertyName)
-        }
-    }
-
-}
-
-
 public final class RelationshipKeyPathsObserver<Object: NSManagedObject>: NSObject {
 
     private let keyPaths: Set<RelationshipKeyPath>
@@ -143,3 +75,16 @@ public final class RelationshipKeyPathsObserver<Object: NSManagedObject>: NSObje
 
 }
 
+private extension NSManagedObject {
+
+    /// Matches the given key paths to the current changes of this `NSManagedObject`.
+    /// - Parameter keyPaths: The key paths to match the changes for.
+    /// - Returns: The matching relationship key path if found. Otherwise, `nil`.
+    func changedKeyPath(from keyPaths: Set<RelationshipKeyPath>, refreshed: Bool) -> RelationshipKeyPath? {
+        return keyPaths.first { keyPath -> Bool in
+            guard keyPath.destinationEntityName == entity.name || keyPath.destinationEntityName == entity.superentity?.name else { return false }
+            return refreshed || changedValues().keys.contains(keyPath.destinationPropertyName)
+        }
+    }
+
+}

--- a/Common/Data/RichFetchRequest.swift
+++ b/Common/Data/RichFetchRequest.swift
@@ -47,7 +47,6 @@ public struct RelationshipKeyPath: Hashable {
         self.relationshipKeyPaths = relationships2.map { $0?.name ?? "" }
         self.inverseRelationshipKeyPaths = inverseRelationship.map { $0?.name ?? "" }
 
-//        assert(!self.destinationPropertyName.isEmpty, "Invalid key path is used")
         assert(!self.destinationEntityName.isEmpty, "Invalid key path is used")
         self.relationshipKeyPaths.forEach { property in
             assert(!property.isEmpty, "Invalid key path is used")
@@ -58,142 +57,6 @@ public struct RelationshipKeyPath: Hashable {
     }
 
 }
-
-///// Observes relationship key paths and refreshes Core Data objects accordingly once the related managed object context saves.
-//public final class RelationshipKeyPathsObserver<ResultType: NSFetchRequestResult>: NSObject {
-//
-//    private let keyPaths: Set<RelationshipKeyPath>
-//    private weak var fetchedResultsController: NSFetchedResultsController<ResultType>?
-//
-//    private var updatedObjectIDs: Set<NSManagedObjectID> = []
-//
-//    public init?(fetchedResultsController: NSFetchedResultsController<ResultType>, keyPaths: Set<String>) {
-//        guard !keyPaths.isEmpty else { return nil }
-//
-//        self.fetchedResultsController = fetchedResultsController
-//        let relationships = fetchedResultsController.fetchRequest.entity?.relationshipsByName
-//        self.keyPaths = Set(keyPaths.map { keyPath in
-//            return RelationshipKeyPath(keyPath: keyPath, relationships: relationships)
-//        })
-//
-//        super.init()
-//
-//        NotificationCenter.default.addObserver(self,
-//                                               selector: #selector(contextDidChangeNotification(notification:)),
-//                                               name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
-//                                               object: fetchedResultsController.managedObjectContext)
-//        NotificationCenter.default.addObserver(self,
-//                                               selector: #selector(contextDidSaveNotification(notification:)),
-//                                               name: NSNotification.Name.NSManagedObjectContextDidSave,
-//                                               object: fetchedResultsController.managedObjectContext)
-//    }
-//
-//    @objc private func contextDidChangeNotification(notification: NSNotification) {
-//        if let updatedObjects = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject> {
-//            guard let updatedObjectIDs = updatedObjects.updatedObjectIDs(for: self.keyPaths), !updatedObjectIDs.isEmpty else { return }
-//            self.updatedObjectIDs = self.updatedObjectIDs.union(updatedObjectIDs)
-//        }
-//
-//        if let updatedObjects = notification.userInfo?[NSRefreshedObjectsKey] as? Set<NSManagedObject> {
-//            updatedObjects.forEach { object in
-//                guard let changedRelationshipKeyPath = object.changedKeyPath(from: self.keyPaths, refreshed: true) else { return }
-//
-//                let firstKeyPath = changedRelationshipKeyPath.relationshipKeyPaths.first ?? ""
-//
-//                var inverseRelationshipKeyPaths: [String] = changedRelationshipKeyPath.inverseRelationshipKeyPaths.reversed()
-//                let lastInverseRelationshipKeyPath = inverseRelationshipKeyPaths.popLast() ?? ""
-//
-//                var objects: Set<NSManagedObject> = [object]
-//
-//                for inverseRelationshipKeyPath in inverseRelationshipKeyPaths {
-//                    let values = objects.compactMap { object in object.value(forKey: inverseRelationshipKeyPath) }
-//                    objects.removeAll()
-//
-//                    for value in values {
-//                        if let toManyObjects = value as? Set<NSManagedObject> {
-//                            objects.formUnion(toManyObjects)
-//                        } else if let toOneObject = value as? NSManagedObject {
-//                            objects.insert(toOneObject)
-//                        } else {
-//                            assertionFailure("Invalid relationship observed for keyPath: \(changedRelationshipKeyPath)")
-//                            return
-//                        }
-//                    }
-//                }
-//
-//                let fetchObjects = self.fetchedResultsController.fetchedObjects as? [NSManagedObject]
-//                let fetchObjectIDs = fetchObjects?.map(\.objectID) ?? []
-//
-//                self.fetchedResultsController?.managedObjectContext.performAndWait {
-//                    for object in objects {
-//                        let value = object.value(forKey: lastInverseRelationshipKeyPath)
-//
-//                        if let toManyObjects = value as? Set<NSManagedObject> {
-//                            for obj in toManyObjects where fetchObjectIDs.contains(obj.objectID) {
-//                                obj.setValue(object, forKeyPath: firstKeyPath)
-//                            }
-//                        } else if let toOneObject = value as? NSManagedObject, fetchObjectIDs.contains(toOneObject.objectID) {
-//                            toOneObject.setValue(object, forKeyPath: firstKeyPath)
-//                        } else {
-//                            assertionFailure("Invalid relationship observed for keyPath: \(lastInverseRelationshipKeyPath)")
-//                            return
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//    }
-//
-//    @objc private func contextDidSaveNotification(notification: NSNotification) {
-//        guard !self.updatedObjectIDs.isEmpty else { return }
-//        guard let fetchedObjects = self.fetchedResultsController?.fetchedObjects as? [NSManagedObject], !fetchedObjects.isEmpty else { return }
-//
-//        fetchedObjects.forEach { object in
-//            guard self.updatedObjectIDs.contains(object.objectID) else { return }
-//            self.fetchedResultsController?.managedObjectContext.refresh(object, mergeChanges: true)
-//        }
-//
-//        self.updatedObjectIDs.removeAll()
-//    }
-//
-//}
-
-//extension Set where Element: NSManagedObject {
-//
-//    /// Iterates over the objects and returns the object IDs that matched our observing keyPaths.
-//    /// - Parameter keyPaths: The keyPaths to observe changes for.
-//    func updatedObjectIDs(for keyPaths: Set<RelationshipKeyPath>, refreshed: Bool = false) -> Set<NSManagedObjectID>? {
-//        var objectIDs: Set<NSManagedObjectID> = []
-//        self.forEach { object in
-//            guard let changedRelationshipKeyPath = object.changedKeyPath(from: keyPaths, refreshed: refreshed) else { return }
-//
-//            let inverseRelationshipKeyPaths = changedRelationshipKeyPath.inverseRelationshipKeyPaths.reversed()
-//
-//            var objects: Set<NSManagedObject> = [object]
-//
-//            for inverseRelationshipKeyPath in inverseRelationshipKeyPaths {
-//                let values = objects.map { object in object.value(forKey: inverseRelationshipKeyPath) }
-//                objects.removeAll()
-//
-//                for value in values {
-//                    if let toManyObjects = value as? Set<NSManagedObject> {
-//                        objects.formUnion(toManyObjects)
-//                    } else if let toOneObject = value as? NSManagedObject {
-//                        objects.insert(toOneObject)
-//                    } else {
-//                        assertionFailure("Invalid relationship observed for keyPath: \(changedRelationshipKeyPath)")
-//                        return
-//                    }
-//                }
-//            }
-//
-//            objectIDs.formUnion(objects.map(\.objectID))
-//        }
-//
-//        return objectIDs
-//    }
-//
-//}
 
 private extension NSManagedObject {
 
@@ -210,8 +73,7 @@ private extension NSManagedObject {
 }
 
 
-
-public final class RelationshipKeyPathsObserver2<Object: NSManagedObject>: NSObject {
+public final class RelationshipKeyPathsObserver<Object: NSManagedObject>: NSObject {
 
     private let keyPaths: Set<RelationshipKeyPath>
 

--- a/Common/Data/RichFetchRequest.swift
+++ b/Common/Data/RichFetchRequest.swift
@@ -125,7 +125,7 @@ public final class RelationshipKeyPathsObserver<Object: NSManagedObject>: NSObje
 
                 managedObjectContext.performAndWait {
                     for object in objects {
-                        let value = object.value(forKey: lastInverseRelationshipKeyPath)
+                        guard let value = object.value(forKey: lastInverseRelationshipKeyPath) else { continue }
 
                         if let toManyObjects = value as? Set<NSManagedObject> {
                             toManyObjects.forEach { $0.setValue(object, forKeyPath: firstKeyPath) }

--- a/Common/Data/RichFetchRequest.swift
+++ b/Common/Data/RichFetchRequest.swift
@@ -1,0 +1,283 @@
+//
+//  Created for xikolo-ios under MIT license.
+//  Copyright © HPI. All rights reserved.
+//
+
+import CoreData
+
+/// Describes a relationship key path for a Core Data entity.
+public struct RelationshipKeyPath: Hashable {
+
+    /// The destination property name we're observing
+    let destinationPropertyName: String
+
+    let destinationEntityName: String
+
+    let relationshipKeyPaths: [String]
+
+    /// The inverse property names of this relationship. Can be used to get the affected object IDs.
+    let inverseRelationshipKeyPaths: [String]
+
+    public init(keyPath: String, relationships: [String: NSRelationshipDescription]?) {
+        let splittedKeyPath = keyPath.split(separator: ".").map(String.init)
+
+        var destinationEntity: NSEntityDescription?
+        var relationships2: [NSRelationshipDescription?] = []
+        var inverseRelationship: [NSRelationshipDescription?] = []
+        var destinationProperty: NSPropertyDescription?
+
+        var relationshipsByName: [String: NSRelationshipDescription]? = relationships
+        var propertiesByName: [String: NSPropertyDescription]? = [:]
+        for relationshipName in splittedKeyPath {
+            if let relationship = relationshipsByName?[relationshipName] {
+                destinationEntity = relationship.destinationEntity
+                relationships2.append(relationship)
+                inverseRelationship.append(relationship.inverseRelationship)
+                relationshipsByName = relationship.destinationEntity?.relationshipsByName
+                propertiesByName = relationship.destinationEntity?.propertiesByName
+            } else if let property = propertiesByName?[relationshipName] {
+                destinationProperty = property
+            } else {
+                assertionFailure("Invalid key path is used")
+            }
+        }
+
+        self.destinationEntityName = destinationEntity?.name ?? ""
+        self.destinationPropertyName = destinationProperty?.name ?? ""
+        self.relationshipKeyPaths = relationships2.map { $0?.name ?? "" }
+        self.inverseRelationshipKeyPaths = inverseRelationship.map { $0?.name ?? "" }
+
+//        assert(!self.destinationPropertyName.isEmpty, "Invalid key path is used")
+        assert(!self.destinationEntityName.isEmpty, "Invalid key path is used")
+        self.relationshipKeyPaths.forEach { property in
+            assert(!property.isEmpty, "Invalid key path is used")
+        }
+        self.inverseRelationshipKeyPaths.forEach { property in
+            assert(!property.isEmpty, "Invalid key path is used")
+        }
+    }
+
+}
+
+///// Observes relationship key paths and refreshes Core Data objects accordingly once the related managed object context saves.
+//public final class RelationshipKeyPathsObserver<ResultType: NSFetchRequestResult>: NSObject {
+//
+//    private let keyPaths: Set<RelationshipKeyPath>
+//    private weak var fetchedResultsController: NSFetchedResultsController<ResultType>?
+//
+//    private var updatedObjectIDs: Set<NSManagedObjectID> = []
+//
+//    public init?(fetchedResultsController: NSFetchedResultsController<ResultType>, keyPaths: Set<String>) {
+//        guard !keyPaths.isEmpty else { return nil }
+//
+//        self.fetchedResultsController = fetchedResultsController
+//        let relationships = fetchedResultsController.fetchRequest.entity?.relationshipsByName
+//        self.keyPaths = Set(keyPaths.map { keyPath in
+//            return RelationshipKeyPath(keyPath: keyPath, relationships: relationships)
+//        })
+//
+//        super.init()
+//
+//        NotificationCenter.default.addObserver(self,
+//                                               selector: #selector(contextDidChangeNotification(notification:)),
+//                                               name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
+//                                               object: fetchedResultsController.managedObjectContext)
+//        NotificationCenter.default.addObserver(self,
+//                                               selector: #selector(contextDidSaveNotification(notification:)),
+//                                               name: NSNotification.Name.NSManagedObjectContextDidSave,
+//                                               object: fetchedResultsController.managedObjectContext)
+//    }
+//
+//    @objc private func contextDidChangeNotification(notification: NSNotification) {
+//        if let updatedObjects = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject> {
+//            guard let updatedObjectIDs = updatedObjects.updatedObjectIDs(for: self.keyPaths), !updatedObjectIDs.isEmpty else { return }
+//            self.updatedObjectIDs = self.updatedObjectIDs.union(updatedObjectIDs)
+//        }
+//
+//        if let updatedObjects = notification.userInfo?[NSRefreshedObjectsKey] as? Set<NSManagedObject> {
+//            updatedObjects.forEach { object in
+//                guard let changedRelationshipKeyPath = object.changedKeyPath(from: self.keyPaths, refreshed: true) else { return }
+//
+//                let firstKeyPath = changedRelationshipKeyPath.relationshipKeyPaths.first ?? ""
+//
+//                var inverseRelationshipKeyPaths: [String] = changedRelationshipKeyPath.inverseRelationshipKeyPaths.reversed()
+//                let lastInverseRelationshipKeyPath = inverseRelationshipKeyPaths.popLast() ?? ""
+//
+//                var objects: Set<NSManagedObject> = [object]
+//
+//                for inverseRelationshipKeyPath in inverseRelationshipKeyPaths {
+//                    let values = objects.compactMap { object in object.value(forKey: inverseRelationshipKeyPath) }
+//                    objects.removeAll()
+//
+//                    for value in values {
+//                        if let toManyObjects = value as? Set<NSManagedObject> {
+//                            objects.formUnion(toManyObjects)
+//                        } else if let toOneObject = value as? NSManagedObject {
+//                            objects.insert(toOneObject)
+//                        } else {
+//                            assertionFailure("Invalid relationship observed for keyPath: \(changedRelationshipKeyPath)")
+//                            return
+//                        }
+//                    }
+//                }
+//
+//                let fetchObjects = self.fetchedResultsController.fetchedObjects as? [NSManagedObject]
+//                let fetchObjectIDs = fetchObjects?.map(\.objectID) ?? []
+//
+//                self.fetchedResultsController?.managedObjectContext.performAndWait {
+//                    for object in objects {
+//                        let value = object.value(forKey: lastInverseRelationshipKeyPath)
+//
+//                        if let toManyObjects = value as? Set<NSManagedObject> {
+//                            for obj in toManyObjects where fetchObjectIDs.contains(obj.objectID) {
+//                                obj.setValue(object, forKeyPath: firstKeyPath)
+//                            }
+//                        } else if let toOneObject = value as? NSManagedObject, fetchObjectIDs.contains(toOneObject.objectID) {
+//                            toOneObject.setValue(object, forKeyPath: firstKeyPath)
+//                        } else {
+//                            assertionFailure("Invalid relationship observed for keyPath: \(lastInverseRelationshipKeyPath)")
+//                            return
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//    }
+//
+//    @objc private func contextDidSaveNotification(notification: NSNotification) {
+//        guard !self.updatedObjectIDs.isEmpty else { return }
+//        guard let fetchedObjects = self.fetchedResultsController?.fetchedObjects as? [NSManagedObject], !fetchedObjects.isEmpty else { return }
+//
+//        fetchedObjects.forEach { object in
+//            guard self.updatedObjectIDs.contains(object.objectID) else { return }
+//            self.fetchedResultsController?.managedObjectContext.refresh(object, mergeChanges: true)
+//        }
+//
+//        self.updatedObjectIDs.removeAll()
+//    }
+//
+//}
+
+//extension Set where Element: NSManagedObject {
+//
+//    /// Iterates over the objects and returns the object IDs that matched our observing keyPaths.
+//    /// - Parameter keyPaths: The keyPaths to observe changes for.
+//    func updatedObjectIDs(for keyPaths: Set<RelationshipKeyPath>, refreshed: Bool = false) -> Set<NSManagedObjectID>? {
+//        var objectIDs: Set<NSManagedObjectID> = []
+//        self.forEach { object in
+//            guard let changedRelationshipKeyPath = object.changedKeyPath(from: keyPaths, refreshed: refreshed) else { return }
+//
+//            let inverseRelationshipKeyPaths = changedRelationshipKeyPath.inverseRelationshipKeyPaths.reversed()
+//
+//            var objects: Set<NSManagedObject> = [object]
+//
+//            for inverseRelationshipKeyPath in inverseRelationshipKeyPaths {
+//                let values = objects.map { object in object.value(forKey: inverseRelationshipKeyPath) }
+//                objects.removeAll()
+//
+//                for value in values {
+//                    if let toManyObjects = value as? Set<NSManagedObject> {
+//                        objects.formUnion(toManyObjects)
+//                    } else if let toOneObject = value as? NSManagedObject {
+//                        objects.insert(toOneObject)
+//                    } else {
+//                        assertionFailure("Invalid relationship observed for keyPath: \(changedRelationshipKeyPath)")
+//                        return
+//                    }
+//                }
+//            }
+//
+//            objectIDs.formUnion(objects.map(\.objectID))
+//        }
+//
+//        return objectIDs
+//    }
+//
+//}
+
+private extension NSManagedObject {
+
+    /// Matches the given key paths to the current changes of this `NSManagedObject`.
+    /// - Parameter keyPaths: The key paths to match the changes for.
+    /// - Returns: The matching relationship key path if found. Otherwise, `nil`.
+    func changedKeyPath(from keyPaths: Set<RelationshipKeyPath>, refreshed: Bool) -> RelationshipKeyPath? {
+        return keyPaths.first { keyPath -> Bool in
+            guard keyPath.destinationEntityName == entity.name || keyPath.destinationEntityName == entity.superentity?.name else { return false }
+            return refreshed || changedValues().keys.contains(keyPath.destinationPropertyName)
+        }
+    }
+
+}
+
+
+
+public final class RelationshipKeyPathsObserver2<Object: NSManagedObject>: NSObject {
+
+    private let keyPaths: Set<RelationshipKeyPath>
+
+    public init?(for entityType: Object.Type, managedObjectContext: NSManagedObjectContext, keyPaths: Set<String>) {
+        guard !keyPaths.isEmpty else { return nil }
+
+        let relationships = entityType.entity().relationshipsByName
+        self.keyPaths = Set(keyPaths.compactMap { keyPath in
+            return RelationshipKeyPath(keyPath: keyPath, relationships: relationships)
+        })
+
+        super.init()
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(contextDidChangeNotification(notification:)),
+                                               name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
+                                               object: managedObjectContext)
+    }
+
+    @objc private func contextDidChangeNotification(notification: NSNotification) {
+        guard let managedObjectContext = notification.object as? NSManagedObjectContext else { return }
+
+        if let updatedObjects = notification.userInfo?[NSRefreshedObjectsKey] as? Set<NSManagedObject> {
+            updatedObjects.forEach { object in
+                guard let changedRelationshipKeyPath = object.changedKeyPath(from: self.keyPaths, refreshed: true) else { return }
+
+                let firstKeyPath = changedRelationshipKeyPath.relationshipKeyPaths.first ?? ""
+
+                var inverseRelationshipKeyPaths: [String] = changedRelationshipKeyPath.inverseRelationshipKeyPaths.reversed()
+                let lastInverseRelationshipKeyPath = inverseRelationshipKeyPaths.popLast() ?? ""
+
+                var objects: Set<NSManagedObject> = [object]
+
+                for inverseRelationshipKeyPath in inverseRelationshipKeyPaths {
+                    let values = objects.compactMap { object in object.value(forKey: inverseRelationshipKeyPath) }
+                    objects.removeAll()
+
+                    for value in values {
+                        if let toManyObjects = value as? Set<NSManagedObject> {
+                            objects.formUnion(toManyObjects)
+                        } else if let toOneObject = value as? NSManagedObject {
+                            objects.insert(toOneObject)
+                        } else {
+                            assertionFailure("Invalid relationship observed for keyPath: \(changedRelationshipKeyPath)")
+                            return
+                        }
+                    }
+                }
+
+                managedObjectContext.performAndWait {
+                    for object in objects {
+                        let value = object.value(forKey: lastInverseRelationshipKeyPath)
+
+                        if let toManyObjects = value as? Set<NSManagedObject> {
+                            toManyObjects.forEach { $0.setValue(object, forKeyPath: firstKeyPath) }
+                        } else if let toOneObject = value as? NSManagedObject {
+                            toOneObject.setValue(object, forKeyPath: firstKeyPath)
+                        } else {
+                            assertionFailure("Invalid relationship observed for keyPath: \(lastInverseRelationshipKeyPath)")
+                            return
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+}
+

--- a/Common/Extensions/Notification+CoreData.swift
+++ b/Common/Extensions/Notification+CoreData.swift
@@ -7,14 +7,30 @@ import CoreData
 
 extension Notification {
 
-    public static var allCoreDataNotificationKeys: [String] {
-        return [NSUpdatedObjectsKey, NSInsertedObjectsKey, NSDeletedObjectsKey, NSRefreshedObjectsKey]
+    public enum CoreDataNotificationKey: CaseIterable {
+        case updated
+        case inserted
+        case deleted
+        case refreshed
+
+        var keyName: String {
+            switch self {
+            case .updated: return NSUpdatedObjectsKey
+            case .inserted: return NSInsertedObjectsKey
+            case .deleted: return NSDeletedObjectsKey
+            case .refreshed: return NSRefreshedObjectsKey
+            }
+        }
     }
 
-    public func includesChanges<T>(for type: T.Type, keys: [String] = Notification.allCoreDataNotificationKeys) -> Bool where T: NSManagedObject {
+    public func includesChanges<T>(for type: T.Type, key: CoreDataNotificationKey) -> Bool where T: NSManagedObject {
+        guard let objects = self.userInfo?[key.keyName] as? Set<NSManagedObject>, !objects.isEmpty else { return false }
+        return objects.contains { $0 is T }
+    }
+
+    public func includesChanges<T>(for type: T.Type, keys: [CoreDataNotificationKey] = CoreDataNotificationKey.allCases) -> Bool where T: NSManagedObject {
         return keys.map { key in
-            guard let objects = self.userInfo?[key] as? Set<NSManagedObject>, !objects.isEmpty else { return false }
-            return objects.contains { $0 is T }
+            return self.includesChanges(for: type, key: key)
         }.contains(true)
     }
 

--- a/Common/Extensions/Notification+CoreData.swift
+++ b/Common/Extensions/Notification+CoreData.swift
@@ -15,10 +15,14 @@ extension Notification {
 
         var keyName: String {
             switch self {
-            case .updated: return NSUpdatedObjectsKey
-            case .inserted: return NSInsertedObjectsKey
-            case .deleted: return NSDeletedObjectsKey
-            case .refreshed: return NSRefreshedObjectsKey
+            case .updated:
+                return NSUpdatedObjectsKey
+            case .inserted:
+                return NSInsertedObjectsKey
+            case .deleted:
+                return NSDeletedObjectsKey
+            case .refreshed:
+                return NSRefreshedObjectsKey
             }
         }
     }

--- a/iOS/ViewControllers/Account/DownloadedContentListViewController.swift
+++ b/iOS/ViewControllers/Account/DownloadedContentListViewController.swift
@@ -104,9 +104,8 @@ class DownloadedContentListViewController: UITableViewController {
     }
 
     @objc private func coreDataChange(notification: Notification) {
-        let keys = [NSDeletedObjectsKey, NSRefreshedObjectsKey, NSUpdatedObjectsKey]
-        let containsVideoDeletion = notification.includesChanges(for: Video.self, keys: keys)
-        let containsDocumentDeletion = notification.includesChanges(for: DocumentLocalization.self, keys: keys)
+        let containsVideoDeletion = notification.includesChanges(for: Video.self, keys: [.deleted, .refreshed])
+        let containsDocumentDeletion = notification.includesChanges(for: DocumentLocalization.self, keys: [.deleted, .refreshed])
         if containsVideoDeletion || containsDocumentDeletion {
             self.refresh()
         }

--- a/iOS/ViewControllers/Account/DownloadedContentListViewController.swift
+++ b/iOS/ViewControllers/Account/DownloadedContentListViewController.swift
@@ -5,7 +5,6 @@
 
 import BrightFutures
 import Common
-import CoreData
 import Foundation
 import UIKit
 

--- a/iOS/ViewControllers/Courses/CourseListViewController.swift
+++ b/iOS/ViewControllers/Courses/CourseListViewController.swift
@@ -15,7 +15,7 @@ import UIKit
 class CourseListViewController: CustomWidthCollectionViewController {
 
     private var dataSource: CoreDataCollectionViewDataSource<CourseListViewController>!
-    private var relationshipKeyPathsObserver: RelationshipKeyPathsObserver2<Course>?
+    private var relationshipKeyPathsObserver: RelationshipKeyPathsObserver<Course>?
     private var channelObserver: ManagedObjectObserver?
 
     @available(iOS, obsoleted: 11.0)
@@ -74,7 +74,7 @@ class CourseListViewController: CustomWidthCollectionViewController {
                                                            cellReuseIdentifier: reuseIdentifier,
                                                            headerReuseIdentifier: R.nib.courseHeaderView.name,
                                                            delegate: self)
-        self.relationshipKeyPathsObserver = RelationshipKeyPathsObserver2(for: Course.self, managedObjectContext: CoreDataHelper.viewContext, keyPaths: [
+        self.relationshipKeyPathsObserver = RelationshipKeyPathsObserver(for: Course.self,managedObjectContext: CoreDataHelper.viewContext, keyPaths: [
             #keyPath(Course.enrollment),
             #keyPath(Course.channel),
         ])

--- a/iOS/ViewControllers/Courses/CourseListViewController.swift
+++ b/iOS/ViewControllers/Courses/CourseListViewController.swift
@@ -15,6 +15,7 @@ import UIKit
 class CourseListViewController: CustomWidthCollectionViewController {
 
     private var dataSource: CoreDataCollectionViewDataSource<CourseListViewController>!
+    private var relationshipKeyPathsObserver: RelationshipKeyPathsObserver2<Course>?
     private var channelObserver: ManagedObjectObserver?
 
     @available(iOS, obsoleted: 11.0)
@@ -73,6 +74,10 @@ class CourseListViewController: CustomWidthCollectionViewController {
                                                            cellReuseIdentifier: reuseIdentifier,
                                                            headerReuseIdentifier: R.nib.courseHeaderView.name,
                                                            delegate: self)
+        self.relationshipKeyPathsObserver = RelationshipKeyPathsObserver2(for: Course.self, managedObjectContext: CoreDataHelper.viewContext, keyPaths: [
+            #keyPath(Course.enrollment),
+            #keyPath(Course.channel),
+        ])
 
         self.refresh()
 

--- a/iOS/ViewControllers/Courses/CourseListViewController.swift
+++ b/iOS/ViewControllers/Courses/CourseListViewController.swift
@@ -74,7 +74,7 @@ class CourseListViewController: CustomWidthCollectionViewController {
                                                            cellReuseIdentifier: reuseIdentifier,
                                                            headerReuseIdentifier: R.nib.courseHeaderView.name,
                                                            delegate: self)
-        self.relationshipKeyPathsObserver = RelationshipKeyPathsObserver(for: Course.self,managedObjectContext: CoreDataHelper.viewContext, keyPaths: [
+        self.relationshipKeyPathsObserver = RelationshipKeyPathsObserver(for: Course.self, managedObjectContext: CoreDataHelper.viewContext, keyPaths: [
             #keyPath(Course.enrollment),
             #keyPath(Course.channel),
         ])

--- a/iOS/ViewControllers/Dashboard/CourseDateOverviewViewController.swift
+++ b/iOS/ViewControllers/Dashboard/CourseDateOverviewViewController.swift
@@ -132,9 +132,10 @@ class CourseDateOverviewViewController: UIViewController {
 
     @objc private func coreDataChange(notification: Notification) {
         let courseDatesChanged = notification.includesChanges(for: CourseDate.self)
-        let courseRefreshed = notification.includesChanges(for: Course.self, keys: [NSRefreshedObjectsKey])
+        let courseRefreshed = notification.includesChanges(for: Course.self, key: .refreshed)
+        let enrollmentRefreshed = notification.includesChanges(for: Enrollment.self, key: .refreshed)
 
-        if courseDatesChanged || courseRefreshed {
+        if courseDatesChanged || courseRefreshed || enrollmentRefreshed {
             self.loadData()
         }
     }

--- a/iOS/ViewControllers/Dashboard/CourseOverviewViewController.swift
+++ b/iOS/ViewControllers/Dashboard/CourseOverviewViewController.swift
@@ -145,7 +145,7 @@ class CourseOverviewViewController: UIViewController {
         let courseChanged = notification.includesChanges(for: Course.self)
         let enrollmentRefreshed = notification.includesChanges(for: Enrollment.self, key: .refreshed)
 
-        if courseChanged  || enrollmentRefreshed {
+        if courseChanged || enrollmentRefreshed {
             self.refresh()
         }
     }

--- a/iOS/ViewControllers/Dashboard/CourseOverviewViewController.swift
+++ b/iOS/ViewControllers/Dashboard/CourseOverviewViewController.swift
@@ -142,8 +142,12 @@ class CourseOverviewViewController: UIViewController {
     }
 
     @objc private func coreDataChange(notification: Notification) {
-        guard notification.includesChanges(for: Course.self) else { return }
-        self.refresh()
+        let courseChanged = notification.includesChanges(for: Course.self)
+        let enrollmentRefreshed = notification.includesChanges(for: Enrollment.self, key: .refreshed)
+
+        if courseChanged  || enrollmentRefreshed {
+            self.refresh()
+        }
     }
 
 }

--- a/iOS/ViewControllers/More/AnnouncementListViewController.swift
+++ b/iOS/ViewControllers/More/AnnouncementListViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 class AnnouncementListViewController: CustomWidthTableViewController {
 
     private var dataSource: CoreDataTableViewDataSourceWrapper<Announcement>!
+    private var relationshipKeyPathsObserver: RelationshipKeyPathsObserver2<Announcement>?
 
     weak var scrollDelegate: CourseAreaScrollDelegate?
 
@@ -34,10 +35,6 @@ class AnnouncementListViewController: CustomWidthTableViewController {
 
         self.addRefreshControl()
 
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(coreDataChange(notification:)),
-                                               name: NSNotification.Name.NSManagedObjectContextObjectsDidChange,
-                                               object: CoreDataHelper.viewContext)
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(updateUIAfterLoginStateChanged),
                                                name: UserProfileHelper.loginStateDidChangeNotification,
@@ -63,6 +60,13 @@ class AnnouncementListViewController: CustomWidthTableViewController {
                                                                  fetchedResultsController: resultsController,
                                                                  cellReuseIdentifier: reuseIdentifier,
                                                                  delegate: self)
+//        self.relationshipKeyPathsObserver = RelationshipKeyPathsObserver(fetchedResultsController: resultsController, keyPaths: [
+//            #keyPath(Announcement.course.enrollment),
+//        ])
+
+        self.relationshipKeyPathsObserver = RelationshipKeyPathsObserver2(for: Announcement.self,
+                                                                          managedObjectContext: resultsController.managedObjectContext,
+                                                                          keyPaths: [#keyPath(Announcement.course.enrollment.objectStateValue)])
 
         self.refresh()
         self.setupEmptyState()
@@ -119,11 +123,6 @@ class AnnouncementListViewController: CustomWidthTableViewController {
         alert.addCancelAction()
 
         self.present(alert, animated: trueUnlessReduceMotionEnabled)
-    }
-
-    @objc private func coreDataChange(notification: Notification) {
-        guard notification.includesChanges(for: Enrollment.self, keys: [NSUpdatedObjectsKey, NSRefreshedObjectsKey]) else { return }
-        self.tableView.reloadData()
     }
 
 }

--- a/iOS/ViewControllers/More/AnnouncementListViewController.swift
+++ b/iOS/ViewControllers/More/AnnouncementListViewController.swift
@@ -11,7 +11,7 @@ import UIKit
 class AnnouncementListViewController: CustomWidthTableViewController {
 
     private var dataSource: CoreDataTableViewDataSourceWrapper<Announcement>!
-    private var relationshipKeyPathsObserver: RelationshipKeyPathsObserver2<Announcement>?
+    private var relationshipKeyPathsObserver: RelationshipKeyPathsObserver<Announcement>?
 
     weak var scrollDelegate: CourseAreaScrollDelegate?
 
@@ -60,13 +60,9 @@ class AnnouncementListViewController: CustomWidthTableViewController {
                                                                  fetchedResultsController: resultsController,
                                                                  cellReuseIdentifier: reuseIdentifier,
                                                                  delegate: self)
-//        self.relationshipKeyPathsObserver = RelationshipKeyPathsObserver(fetchedResultsController: resultsController, keyPaths: [
-//            #keyPath(Announcement.course.enrollment),
-//        ])
-
-        self.relationshipKeyPathsObserver = RelationshipKeyPathsObserver2(for: Announcement.self,
-                                                                          managedObjectContext: resultsController.managedObjectContext,
-                                                                          keyPaths: [#keyPath(Announcement.course.enrollment.objectStateValue)])
+        self.relationshipKeyPathsObserver = RelationshipKeyPathsObserver(for: Announcement.self,
+                                                                         managedObjectContext: resultsController.managedObjectContext,
+                                                                         keyPaths: [#keyPath(Announcement.course.enrollment)])
 
         self.refresh()
         self.setupEmptyState()

--- a/xikolo-ios.xcodeproj/project.pbxproj
+++ b/xikolo-ios.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		5050D665239F971100E48498 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 2493481A1D9550FD006D4F2C /* Localizable.stringsdict */; };
 		5050D66723A00FDA00E48498 /* CourseItem+base62UUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5050D66623A00FDA00E48498 /* CourseItem+base62UUID.swift */; };
 		5050D66923A0125700E48498 /* CourseItemBase62UUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5050D66823A0125700E48498 /* CourseItemBase62UUIDTests.swift */; };
+		50522A4C24FCEEC800A0171F /* RichFetchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50522A4B24FCEEC800A0171F /* RichFetchRequest.swift */; };
 		5052D27721591E9400927D52 /* SyncPushEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5052D27621591E9400927D52 /* SyncPushEngine.swift */; };
 		5052D27A2159208100927D52 /* XikoloSyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5052D2792159208100927D52 /* XikoloSyncEngine.swift */; };
 		5054B2DD21087D6800CE9067 /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5054B2DC21087D6800CE9067 /* Document.swift */; };
@@ -775,6 +776,7 @@
 		50502E2F1FD04E59000A8D35 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/CourseLearnings.strings; sourceTree = "<group>"; };
 		5050D66623A00FDA00E48498 /* CourseItem+base62UUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CourseItem+base62UUID.swift"; sourceTree = "<group>"; };
 		5050D66823A0125700E48498 /* CourseItemBase62UUIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseItemBase62UUIDTests.swift; sourceTree = "<group>"; };
+		50522A4B24FCEEC800A0171F /* RichFetchRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichFetchRequest.swift; sourceTree = "<group>"; };
 		5052D27621591E9400927D52 /* SyncPushEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPushEngine.swift; sourceTree = "<group>"; };
 		5052D2792159208100927D52 /* XikoloSyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XikoloSyncEngine.swift; sourceTree = "<group>"; };
 		5054B2DB21086CF600CE9067 /* xikolo 7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "xikolo 7.xcdatamodel"; sourceTree = "<group>"; };
@@ -1355,6 +1357,7 @@
 				501212081FCC65B00022A7AF /* ModelObserver.swift */,
 				505641E42119B9A6009FC4F0 /* ObjectsDidChangeNotification.swift */,
 				5095168824B75ED300B25F56 /* XikoloSecureUnarchiveFromDataTransformer.swift */,
+				50522A4B24FCEEC800A0171F /* RichFetchRequest.swift */,
 				24597D241CC6CA0D00FB5338 /* xikolo.xcdatamodeld */,
 			);
 			path = Data;
@@ -3362,6 +3365,7 @@
 				50FA2E2720E4B24A00656776 /* PeerAssessmentHelper+FetchRequests.swift in Sources */,
 				50FA2E4C20E4B25800656776 /* Video.swift in Sources */,
 				507F7FDA2372DA450031DC0B /* CourseProgressHelper+FetchRequests.swift in Sources */,
+				50522A4C24FCEEC800A0171F /* RichFetchRequest.swift in Sources */,
 				50FA2E4520E4B25800656776 /* RichText.swift in Sources */,
 				50046F6D216B53EB00D59073 /* Notification+CoreData.swift in Sources */,
 				5037FC16242DF76700B4E8CE /* UIImage+placeholder.swift in Sources */,

--- a/xikolo-ios.xcodeproj/project.pbxproj
+++ b/xikolo-ios.xcodeproj/project.pbxproj
@@ -142,7 +142,7 @@
 		5050D665239F971100E48498 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 2493481A1D9550FD006D4F2C /* Localizable.stringsdict */; };
 		5050D66723A00FDA00E48498 /* CourseItem+base62UUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5050D66623A00FDA00E48498 /* CourseItem+base62UUID.swift */; };
 		5050D66923A0125700E48498 /* CourseItemBase62UUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5050D66823A0125700E48498 /* CourseItemBase62UUIDTests.swift */; };
-		50522A4C24FCEEC800A0171F /* RichFetchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50522A4B24FCEEC800A0171F /* RichFetchRequest.swift */; };
+		50522A4C24FCEEC800A0171F /* RelationshipKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50522A4B24FCEEC800A0171F /* RelationshipKeyPath.swift */; };
 		5052D27721591E9400927D52 /* SyncPushEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5052D27621591E9400927D52 /* SyncPushEngine.swift */; };
 		5052D27A2159208100927D52 /* XikoloSyncEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5052D2792159208100927D52 /* XikoloSyncEngine.swift */; };
 		5054B2DD21087D6800CE9067 /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5054B2DC21087D6800CE9067 /* Document.swift */; };
@@ -420,6 +420,7 @@
 		50FA2E6620E51B7E00656776 /* ReachabilityHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B15BE01FDFE93D00CD86F1 /* ReachabilityHelper.swift */; };
 		50FB7122232BBDC700359BB2 /* UIView+backgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FB7121232BBDC700359BB2 /* UIView+backgroundColor.swift */; };
 		50FE0F3F236C5F4000057A17 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 50FE0F41236C5F4000057A17 /* Localizable.strings */; };
+		50FF4509250A34CF00A4D055 /* RelationshipKeyPathsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FF4508250A34CF00A4D055 /* RelationshipKeyPathsObserver.swift */; };
 		700398C021A437CD00FE9D81 /* FileManager+fileSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700398BF21A437CD00FE9D81 /* FileManager+fileSize.swift */; };
 		700398C221A96E4F00FE9D81 /* AvailableCertificatesListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700398C121A96E4F00FE9D81 /* AvailableCertificatesListViewController.swift */; };
 		700398C421A998B600FE9D81 /* EnrollmentHelper+FetchRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700398C321A998B600FE9D81 /* EnrollmentHelper+FetchRequests.swift */; };
@@ -776,7 +777,7 @@
 		50502E2F1FD04E59000A8D35 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/CourseLearnings.strings; sourceTree = "<group>"; };
 		5050D66623A00FDA00E48498 /* CourseItem+base62UUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CourseItem+base62UUID.swift"; sourceTree = "<group>"; };
 		5050D66823A0125700E48498 /* CourseItemBase62UUIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseItemBase62UUIDTests.swift; sourceTree = "<group>"; };
-		50522A4B24FCEEC800A0171F /* RichFetchRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichFetchRequest.swift; sourceTree = "<group>"; };
+		50522A4B24FCEEC800A0171F /* RelationshipKeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipKeyPath.swift; sourceTree = "<group>"; };
 		5052D27621591E9400927D52 /* SyncPushEngine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncPushEngine.swift; sourceTree = "<group>"; };
 		5052D2792159208100927D52 /* XikoloSyncEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XikoloSyncEngine.swift; sourceTree = "<group>"; };
 		5054B2DB21086CF600CE9067 /* xikolo 7.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "xikolo 7.xcdatamodel"; sourceTree = "<group>"; };
@@ -996,6 +997,7 @@
 		50FE0F40236C5F4000057A17 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		50FE0F42236C5F4500057A17 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		50FE19371FCDB9B700F9D211 /* CourseItemWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseItemWebViewController.swift; sourceTree = "<group>"; };
+		50FF4508250A34CF00A4D055 /* RelationshipKeyPathsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelationshipKeyPathsObserver.swift; sourceTree = "<group>"; };
 		5167825582CF610411E9934A /* Pods-iOS.openwho-ios-release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS.openwho-ios-release.xcconfig"; path = "Target Support Files/Pods-iOS/Pods-iOS.openwho-ios-release.xcconfig"; sourceTree = "<group>"; };
 		538CD7D9C6CC4C74D0C31B4D /* Pods-Stockpile.openwho-ios-release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Stockpile.openwho-ios-release.xcconfig"; path = "Target Support Files/Pods-Stockpile/Pods-Stockpile.openwho-ios-release.xcconfig"; sourceTree = "<group>"; };
 		5764B8650D3700A04FB61051 /* Pods-Common.openwho-ios-release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Common.openwho-ios-release.xcconfig"; path = "Target Support Files/Pods-Common/Pods-Common.openwho-ios-release.xcconfig"; sourceTree = "<group>"; };
@@ -1357,7 +1359,8 @@
 				501212081FCC65B00022A7AF /* ModelObserver.swift */,
 				505641E42119B9A6009FC4F0 /* ObjectsDidChangeNotification.swift */,
 				5095168824B75ED300B25F56 /* XikoloSecureUnarchiveFromDataTransformer.swift */,
-				50522A4B24FCEEC800A0171F /* RichFetchRequest.swift */,
+				50FF4508250A34CF00A4D055 /* RelationshipKeyPathsObserver.swift */,
+				50522A4B24FCEEC800A0171F /* RelationshipKeyPath.swift */,
 				24597D241CC6CA0D00FB5338 /* xikolo.xcdatamodeld */,
 			);
 			path = Data;
@@ -3334,6 +3337,7 @@
 				50B31DFD22C4B660007DDDA4 /* Locale.swift in Sources */,
 				50FA2E1C20E4B24300656776 /* RichTextHelper.swift in Sources */,
 				5054B2E92108BF9B00CE9067 /* DocumentLocalizationHelper+FetchRequest.swift in Sources */,
+				50FF4509250A34CF00A4D055 /* RelationshipKeyPathsObserver.swift in Sources */,
 				5052D27A2159208100927D52 /* XikoloSyncEngine.swift in Sources */,
 				50FA2E4D20E4B25800656776 /* VideoStream.swift in Sources */,
 				50FA2E0A20E4B23600656776 /* BrandColors.swift in Sources */,
@@ -3365,7 +3369,7 @@
 				50FA2E2720E4B24A00656776 /* PeerAssessmentHelper+FetchRequests.swift in Sources */,
 				50FA2E4C20E4B25800656776 /* Video.swift in Sources */,
 				507F7FDA2372DA450031DC0B /* CourseProgressHelper+FetchRequests.swift in Sources */,
-				50522A4C24FCEEC800A0171F /* RichFetchRequest.swift in Sources */,
+				50522A4C24FCEEC800A0171F /* RelationshipKeyPath.swift in Sources */,
 				50FA2E4520E4B25800656776 /* RichText.swift in Sources */,
 				50046F6D216B53EB00D59073 /* Notification+CoreData.swift in Sources */,
 				5037FC16242DF76700B4E8CE /* UIImage+placeholder.swift in Sources */,


### PR DESCRIPTION
Fixes #600

When unenrolling from courses without an Internet connection, the object state of the enrollment is set to `deleted`. Only after reconnecting to the Internet, the enrollment object is deleted from the database. In the meantime, the change to the object state attribute is not reflected in the UI as 'NSFetchedResultsController` does not observe changes in related objects. This includes also not being aware of changes to the number the fetched object via the specified search predicate.

In order to fix this, we have to observe all changes to the database and refresh the data manually if necessary. For this, we need the specify the relationship of the object which shall be observed. I adapted the code from [this blog post](https://www.avanderlee.com/swift/nsfetchedresultscontroller-observe-relationship-changes/) to react to changes which affect to search predicate.

When performing manual fetch requests (not `NSFetchedResultsController`), the changes to the database still have to be observed manually.
