### PR TITLE
Avoid next and previous item buttons overlapping with embedded webview content

### DIFF
--- a/iOS/ViewControllers/Courses/CourseItemWebViewController.swift
+++ b/iOS/ViewControllers/Courses/CourseItemWebViewController.swift
@@ -5,19 +5,31 @@
 
 import Common
 import Foundation
+import WebKit
 
 class CourseItemWebViewController: WebViewController {
 
     var courseItem: CourseItem! {
         didSet {
+            self.userScripts = [self.userScriptForCourseItemInset]
             self.url = self.courseItem.url
         }
     }
 
-    private func setURL() {
-        guard let courseId = self.courseItem.section?.course?.id else { return }
-        guard let courseItemId = self.courseItem.base62id else { return }
-        self.url = Routes.courses.appendingPathComponents([courseId, "items", courseItemId])
+    var userScriptForCourseItemInset: WKUserScript {
+        let script = """
+        const style = document.createElement('style');
+        style.innerHTML = `
+            @media (min-width: 576px) {
+                #maincontent {
+                    padding-left: 84px;
+                    padding-right: 84px;
+                }
+            }
+        `;
+        document.head.appendChild(style);
+        """
+        return WKUserScript(source: script, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
     }
 
 }

--- a/iOS/ViewControllers/Courses/WebViewController.swift
+++ b/iOS/ViewControllers/Courses/WebViewController.swift
@@ -9,7 +9,18 @@ import WebKit
 
 class WebViewController: UIViewController {
 
-    private var webView: WKWebView!
+    private lazy var webView: WKWebView = {
+        let webView = WKWebView(frame: self.view.frame, configuration: self.webViewConfiguration)
+        webView.navigationDelegate = self
+        webView.scrollView.delegate = self
+        return webView
+    }()
+
+    private lazy var webViewConfiguration: WKWebViewConfiguration = {
+        let webViewConfiguration = WKWebViewConfiguration()
+        webViewConfiguration.userContentController = WKUserContentController()
+        return webViewConfiguration
+    }()
 
     weak var scrollDelegate: CourseAreaScrollDelegate?
 
@@ -40,6 +51,15 @@ class WebViewController: UIViewController {
         }
     }
 
+    var userScripts: [WKUserScript] = [] {
+        didSet {
+            self.webViewConfiguration.userContentController.removeAllUserScripts()
+            for userScript in self.userScripts {
+                self.webViewConfiguration.userContentController.addUserScript(userScript)
+            }
+        }
+    }
+
     private var shouldShowToolbar: Bool {
         return self.courseArea == .discussions || self.courseArea == .collabSpace
     }
@@ -64,11 +84,9 @@ class WebViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.initializeWebView()
 
+        self.addWebView()
         self.webView.isHidden = true
-        self.webView.navigationDelegate = self
-        self.webView.scrollView.delegate = self
 
         self.progress.alpha = 0.0
 
@@ -87,17 +105,15 @@ class WebViewController: UIViewController {
         }
     }
 
-    func initializeWebView() {
-         // The manual initialization is necessary due to a bug in MSCoding in iOS 10
-         self.webView = WKWebView(frame: self.view.frame)
-         self.view.addSubview(webView)
-         self.webView.translatesAutoresizingMaskIntoConstraints = false
-         NSLayoutConstraint.activate([
-             self.webView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-             self.webView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
-             self.webView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
-             self.webView.topAnchor.constraint(equalTo: self.view.topAnchor),
-         ])
+    func addWebView() {
+        self.view.addSubview(self.webView)
+        self.webView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            self.webView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            self.webView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            self.webView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            self.webView.topAnchor.constraint(equalTo: self.view.topAnchor),
+        ])
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Fixes #876

### Proposed Changes:
- Fix overlapping content by manipulating the content of the webview
- Inject custom CSS with via JS in the webview
- Improve initialization of webview
- Remove unused code
